### PR TITLE
Added Hulu links for Black Clover and AOT S3

### DIFF
--- a/season_configs/fall_2017.yaml
+++ b/season_configs/fall_2017.yaml
@@ -54,6 +54,7 @@ info:
 streams:
   crunchyroll: 'http://www.crunchyroll.com/black-clover'
   funimation|Funimation: 'https://www.funimation.com/shows/black-clover/'
+  hulu|Hulu: 'https://www.hulu.com/black-clover'
 ---
 title: 'Inuyashiki'
 type: tv

--- a/season_configs/summer_2018.yaml
+++ b/season_configs/summer_2018.yaml
@@ -407,6 +407,7 @@ streams:
   crunchyroll: 'http://www.crunchyroll.com/attack-on-titan|37'
   funimation|Funimation: 'https://www.funimation.com/shows/attack-on-titan/'
   animelab|AnimeLab: 'https://www.animelab.com/shows/attack-on-titan'
+  hulu|Hulu: 'https://www.hulu.com/attack-on-titan'
 ---
 title: 'Shinya! Tensai Bakabon'
 type: tv


### PR DESCRIPTION
I noticed that the discussion posts for Black Clover and Attack on Titan Season 3 didn't have links to Hulu, so I added them in the season configs.

Here are the links for reference:
https://www.hulu.com/black-clover
https://www.hulu.com/attack-on-titan