### PR TITLE
Updated Hulu links for SAO and Black Clover

### DIFF
--- a/season_configs/fall_2017.yaml
+++ b/season_configs/fall_2017.yaml
@@ -51,6 +51,7 @@ info:
   anilist: 'https://anilist.co/anime/97940/BlackClover'
   kitsu: 'https://kitsu.io/anime/black-clover-tv'
   mal: 'https://myanimelist.net/anime/34572/Black_Clover_TV'
+  subreddit: '/r/BlackClover'
 streams:
   crunchyroll: 'http://www.crunchyroll.com/black-clover'
   funimation|Funimation: 'https://www.funimation.com/shows/black-clover/'

--- a/season_configs/fall_2017.yaml
+++ b/season_configs/fall_2017.yaml
@@ -54,7 +54,6 @@ info:
 streams:
   crunchyroll: 'http://www.crunchyroll.com/black-clover'
   funimation|Funimation: 'https://www.funimation.com/shows/black-clover/'
-  hulu|Hulu: 'https://www.hulu.com/black-clover'
 ---
 title: 'Inuyashiki'
 type: tv

--- a/season_configs/fall_2018.yaml
+++ b/season_configs/fall_2018.yaml
@@ -637,6 +637,7 @@ info:
 streams:
   crunchyroll: 'https://www.crunchyroll.com/sword-art-online'
   funimation|Funimation: 'https://www.funimation.com/shows/sword-art-online/'
+  hulu|Hulu: 'https://www.hulu.com/series/sword-art-online-alicization-c22224e3-93c0-40ab-895d-1475d94a6688'
   amazon: ''
   amazon_uk: ''
   hidive: ''


### PR DESCRIPTION
I added the Hulu link for SAO: Alicization to the fall_2018.yaml.
https://www.hulu.com/series/sword-art-online-alicization-c22224e3-93c0-40ab-895d-1475d94a6688

I removed the Hulu link for Black Clover from the fall_2017.yaml because the new episodes (fall 2018 onwards) aren't on Hulu, as you can see [here](https://www.hulu.com/series/black-clover-f6451467-97a8-4ddf-9ae8-e9e4cbb53fc8).