### PR TITLE
remove great pretender

### DIFF
--- a/season_configs/spring_2020.yaml
+++ b/season_configs/spring_2020.yaml
@@ -1116,7 +1116,7 @@ streams:
   amazon|Amazon US: ''
   amazon_uk|Amazon UK: ''
   primevideo|Prime Video International: ''
-  nyaa: 'Great Pretender'
+  nyaa: ''
 #---
 #title: ''
 #alias: ['']


### PR DESCRIPTION
great pretender has all aired, but a fansub group is still working on it. They release their stuff on trusted so it triggers an episode. Stop that.