### PR TITLE
Kamisama ni Natta Hi has no source, it's an anime original

### DIFF
--- a/season_configs/fall_2020.yaml
+++ b/season_configs/fall_2020.yaml
@@ -822,7 +822,7 @@ streams:
 ---
 title: 'Kamisama ni Natta Hi'
 alias: ['The Day I Became a God']
-has_source: true
+has_source: false
 info:
   mal: 'https://myanimelist.net/anime/41930'
   anilist: 'https://anilist.co/anime/118419/Kamisama-ni-Natta-Hi/'


### PR DESCRIPTION
This anime has no source, it's 100% an anime original.

* [Reddit comment on the most recent episode post](https://www.reddit.com/r/anime/comments/jcyafb/kamisama_ni_natta_hi_episode_2_discussion/g94beqz/?context=1)

> Just here to mention this anime is an original and has no source material. Thank you for reading.

* [MAL](https://myanimelist.net/anime/41930), [Anilist](https://anilist.co/anime/118419/Kamisama-ni-Natta-Hi/), etc

> Source: Original 


