### PR TITLE
Make links to current poll easier to click on mobile

### DIFF
--- a/src/services/poll/youpoll.py
+++ b/src/services/poll/youpoll.py
@@ -134,7 +134,7 @@ class PollHandler(AbstractPollHandler):
 	@staticmethod
 	def convert_score_str(score):
 		if score is None:
-			return '-'
+			return '----'
 		elif score <= 1.0: # New style votes
 			return f'{round(100 * score)}%'
 		else:


### PR DESCRIPTION
Make it easier to click the links to polls without scores (such as the poll for the current episode) on mobile, by making the placeholder string longer. A single dash is often difficult to tap on on mobile.