### PR TITLE
Fix stream URL for show

### DIFF
--- a/season_configs/winter_2023.yaml
+++ b/season_configs/winter_2023.yaml
@@ -1271,7 +1271,7 @@ info:
     official: 'https://tondemoskill-anime.com/'
     subreddit: '/r/TondemoSkill'
 streams:
-    crunchyroll: 'https://www.crunchyroll.com/campfire-cooking-in-another-world-with-my-absurd-skills'
+    crunchyroll: 'https://www.crunchyroll.com/campfire-cooking-in-another-world-with-my-absurd-skill'
     museasia: ''
     anione: ''
     funimation|Funimation: ''


### PR DESCRIPTION
Campfire cooking has had its URL changed, from skills to skill. The current URL before this commit now goes to a 404 page.