### PR TITLE
Refactor: change row_factory from tuple to dict

### DIFF
--- a/src/data/database.py
+++ b/src/data/database.py
@@ -21,6 +21,10 @@ def living_in(the_database):
 		return None
 	return DatabaseDatabase(db)
 
+def dict_factory(cursor, row) -> dict:
+    fields = [column[0] for column in cursor.description]
+    return dict(zip(fields, row))
+
 # Database
 
 def db_error(f):
@@ -50,9 +54,10 @@ def db_error_default(default_value):
 	return decorate
 
 class DatabaseDatabase:
-	def __init__(self, db):
+	def __init__(self, db: sqlite3.Connection):
 		self._db = db
-		self.q = db.cursor()
+		self._db.row_factory = dict_factory
+		self.q = self._db.cursor()
 
 		# Set up collations
 		self._db.create_collation("alphanum", _collate_alphanum)
@@ -63,7 +68,7 @@ class DatabaseDatabase:
 		return getattr(self._db, attr)
 
 	def get_count(self):
-		return self.q.fetchone()[0]
+		return self.q.fetchone()['count(*)']
 
 	def save(self):
 		self.commit()
@@ -217,7 +222,7 @@ class DatabaseDatabase:
 			error("ID or key required to get service")
 			return None
 		service = self.q.fetchone()
-		return Service(*service)
+		return Service(**service)
 
 	@db_error_default(list())
 	def get_services(self, enabled=True, disabled=False) -> List[Service]:
@@ -225,11 +230,11 @@ class DatabaseDatabase:
 		if enabled:
 			self.q.execute("SELECT id, key, name, enabled, use_in_post FROM Services WHERE enabled = 1")
 			for service in self.q.fetchall():
-				services.append(Service(*service))
+				services.append(Service(**service))
 		if disabled:
 			self.q.execute("SELECT id, key, name, enabled, use_in_post FROM Services WHERE enabled = 0")
 			for service in self.q.fetchall():
-				services.append(Service(*service))
+				services.append(Service(**service))
 		return services
 
 	@db_error_default(None)
@@ -242,7 +247,7 @@ class DatabaseDatabase:
 			if stream is None:
 				error("Stream {} not found".format(id))
 				return None
-			stream = Stream(*stream)
+			stream = Stream(**stream)
 		elif service_tuple is not None:
 			service, show_key = service_tuple
 			debug("Getting stream for {}/{}".format(service, show_key))
@@ -252,7 +257,7 @@ class DatabaseDatabase:
 			if stream is None:
 				error("Stream {} not found".format(id))
 				return None
-			stream = Stream(*stream)
+			stream = Stream(**stream)
 		else:
 			error("Nothing provided to get stream")
 			return None
@@ -299,7 +304,7 @@ class DatabaseDatabase:
 			return list()
 
 		streams = self.q.fetchall()
-		streams = [Stream(*stream) for stream in streams]
+		streams = [Stream(**stream) for stream in streams]
 		for stream in streams:
 			stream.show = self.get_show(id=stream.show) # convert show id to show model
 		return streams
@@ -359,7 +364,7 @@ class DatabaseDatabase:
 			return list()
 
 		lite_streams = self.q.fetchall()
-		lite_streams = [LiteStream(*lite_stream) for lite_stream in lite_streams]
+		lite_streams = [LiteStream(**lite_stream) for lite_stream in lite_streams]
 		return lite_streams
 
 	@db_error
@@ -381,7 +386,7 @@ class DatabaseDatabase:
 		site = self.q.fetchone()
 		if site is None:
 			return None
-		return LinkSite(*site)
+		return LinkSite(**site)
 
 	@db_error_default(list())
 	def get_link_sites(self, enabled=True, disabled=False) -> List[LinkSite]:
@@ -389,11 +394,11 @@ class DatabaseDatabase:
 		if enabled:
 			self.q.execute("SELECT id, key, name, enabled FROM LinkSites WHERE enabled = 1")
 			for link in self.q.fetchall():
-				sites.append(LinkSite(*link))
+				sites.append(LinkSite(**link))
 		if disabled:
 			self.q.execute("SELECT id, key, name, enabled FROM LinkSites WHERE enabled = 0")
 			for link in self.q.fetchall():
-				sites.append(LinkSite(*link))
+				sites.append(LinkSite(**link))
 		return sites
 
 	@db_error_default(list())
@@ -404,7 +409,7 @@ class DatabaseDatabase:
 			# Get all streams with show ID
 			self.q.execute("SELECT site, show, site_key FROM Links WHERE show = ?", (show.id,))
 			links = self.q.fetchall()
-			links = [Link(*link) for link in links]
+			links = [Link(**link) for link in links]
 			return links
 		else:
 			error("A show must be provided to get links")
@@ -418,7 +423,7 @@ class DatabaseDatabase:
 		link = self.q.fetchone()
 		if link is None:
 			return None
-		link = Link(*link)
+		link = Link(**link)
 		return link
 
 	@db_error_default(False)
@@ -449,15 +454,15 @@ class DatabaseDatabase:
 
 	# Shows
 	@db_error_default(list())
-	def get_shows(self, missing_length=False, missing_stream=False, enabled=True, delayed=False) -> [Show]:
+	def get_shows(self, missing_length=False, missing_stream=False, enabled=True, delayed=False) -> list[Show]:
 		shows = list()
 		if missing_length:
 			self.q.execute(
-				"SELECT id, name, name_en, length, type, has_source, is_nsfw, enabled, delayed FROM Shows \
+				"SELECT id, name, name_en, length, type AS show_type, has_source, is_nsfw, enabled, delayed FROM Shows \
 				WHERE (length IS NULL OR length = '' OR length = 0) AND enabled = ?", (enabled,))
 		elif missing_stream:
 			self.q.execute(
-				"SELECT id, name, name_en, length, type, has_source, is_nsfw, enabled, delayed FROM Shows show\
+				"SELECT id, name, name_en, length, type AS show_type, has_source, is_nsfw, enabled, delayed FROM Shows show\
 				WHERE (SELECT count(*) FROM Streams stream, Services service \
 				       WHERE stream.show = show.id \
 				       AND stream.active = 1 \
@@ -467,14 +472,14 @@ class DatabaseDatabase:
 				(enabled,))
 		elif delayed:
 			self.q.execute(
-				"SELECT id, name, name_en, length, type, has_source, is_nsfw, enabled, delayed FROM Shows \
+				"SELECT id, name, name_en, length, type AS show_type, has_source, is_nsfw, enabled, delayed FROM Shows \
 				WHERE delayed = 1 AND enabled = ?", (enabled,))
 		else:
 			self.q.execute(
-				"SELECT id, name, name_en, length, type, has_source, is_nsfw, enabled, delayed FROM Shows \
+				"SELECT id, name, name_en, length, type AS show_type, has_source, is_nsfw, enabled, delayed FROM Shows \
 				WHERE enabled = ?", (enabled,))
 		for show in self.q.fetchall():
-			show = Show(*show)
+			show = Show(**show)
 			show.aliases = self.get_aliases(show)
 			shows.append(show)
 		return shows
@@ -492,12 +497,12 @@ class DatabaseDatabase:
 			error("Show ID not provided to get_show")
 			return None
 		self.q.execute(
-			"SELECT id, name, name_en, length, type, has_source, is_nsfw, enabled, delayed FROM Shows \
+			"SELECT id, name, name_en, length, type AS show_type, has_source, is_nsfw, enabled, delayed FROM Shows \
 			WHERE id = ?", (id,))
 		show = self.q.fetchone()
 		if show is None:
 			return None
-		show = Show(*show)
+		show = Show(**show)
 		show.aliases = self.get_aliases(show)
 		return show
 
@@ -506,17 +511,17 @@ class DatabaseDatabase:
 		#debug("Getting show from database")
 
 		self.q.execute(
-			"SELECT id, name, name_en, length, type, has_source, is_nsfw, enabled, delayed FROM Shows \
+			"SELECT id, name, name_en, length, type AS show_type, has_source, is_nsfw, enabled, delayed FROM Shows \
 			WHERE name = ?", (name,))
 		show = self.q.fetchone()
 		if show is None:
 			return None
-		show = Show(*show)
+		show = Show(**show)
 		show.aliases = self.get_aliases(show)
 		return show
 
 	@db_error_default(list())
-	def get_aliases(self, show: Show) -> [str]:
+	def get_aliases(self, show: Show) -> list[str]:
 		self.q.execute("SELECT alias FROM Aliases where show = ?", (show.id,))
 		return [s for s, in self.q.fetchall()]
 
@@ -556,7 +561,7 @@ class DatabaseDatabase:
 		is_nsfw = raw_show.is_nsfw
 
 		if name_en:
-		    self.q.execute("UPDATE Shows SET name_en = ? WHERE id = ?", (name_en, show_id))
+			self.q.execute("UPDATE Shows SET name_en = ? WHERE id = ?", (name_en, show_id))
 		if length != 0:
 			self.q.execute("UPDATE Shows SET length = ? WHERE id = ?", (length, show_id))
 		self.q.execute("UPDATE Shows SET type = ?, has_source = ?, is_nsfw = ? WHERE id = ?", (show_type, has_source, is_nsfw, show_id))
@@ -599,10 +604,10 @@ class DatabaseDatabase:
 
 	@db_error_default(None)
 	def get_latest_episode(self, show: Show) -> Optional[Episode]:
-		self.q.execute("SELECT episode, post_url FROM Episodes WHERE show = ? ORDER BY episode DESC LIMIT 1", (show.id,))
+		self.q.execute("SELECT episode AS number, post_url AS link FROM Episodes WHERE show = ? ORDER BY episode DESC LIMIT 1", (show.id,))
 		data = self.q.fetchone()
 		if data is not None:
-			return Episode(data[0], None, data[1], None)
+			return Episode(**data)
 		return None
 
 	@db_error
@@ -614,9 +619,9 @@ class DatabaseDatabase:
 	@db_error_default(list())
 	def get_episodes(self, show, ensure_sorted=True) -> List[Episode]:
 		episodes = list()
-		self.q.execute("SELECT episode, post_url FROM Episodes WHERE show = ?", (show.id,))
+		self.q.execute("SELECT episode AS number, post_url AS link FROM Episodes WHERE show = ?", (show.id,))
 		for data in self.q.fetchall():
-			episodes.append(Episode(data[0], None, data[1], None))
+			episodes.append(Episode(**data))
 
 		if ensure_sorted:
 			episodes = sorted(episodes, key=lambda e: e.number)
@@ -625,13 +630,13 @@ class DatabaseDatabase:
 	# Scores
 	@db_error_default(list())
 	def get_show_scores(self, show: Show) -> List[EpisodeScore]:
-		self.q.execute("SELECT episode, site, score FROM Scores WHERE show=?", (show.id,))
-		return [EpisodeScore(show.id, *s) for s in self.q.fetchall()]
+		self.q.execute("SELECT episode, site AS site_id, score FROM Scores WHERE show=?", (show.id,))
+		return [EpisodeScore(show_id=show.id, **s) for s in self.q.fetchall()]
 
 	@db_error_default(list())
 	def get_episode_scores(self, show: Show, episode: Episode) -> List[EpisodeScore]:
-		self.q.execute("SELECT site, score FROM Scores WHERE show=? AND episode=?", (show.id, episode.number))
-		return [EpisodeScore(show.id, episode.number, *s) for s in self.q.fetchall()]
+		self.q.execute("SELECT site AS site_id, score FROM Scores WHERE show=? AND episode=?", (show.id, episode.number))
+		return [EpisodeScore(show_id=show.id, episode=episode.number, **s) for s in self.q.fetchall()]
 
 	@db_error_default(None)
 	def get_episode_score_avg(self, show: Show, episode: Episode) -> Optional[EpisodeScore]:
@@ -641,7 +646,7 @@ class DatabaseDatabase:
 		if len(scores) > 0:
 			score = sum(scores)/len(scores)
 			debug("  Score: {} (from {} scores)".format(score, len(scores)))
-			return EpisodeScore(show.id, episode.number, None, score)
+			return EpisodeScore(show_id=show.id, episode=episode.number, score=score)
 		return None
 
 	@db_error
@@ -664,7 +669,7 @@ class DatabaseDatabase:
 		site = self.q.fetchone()
 		if site is None:
 			return None
-		return PollSite(*site)
+		return PollSite(**site)
 
 	@db_error
 	def add_poll(self, show: Show, episode: Episode, site: PollSite, poll_id, commit=True):
@@ -681,24 +686,24 @@ class DatabaseDatabase:
 
 	@db_error_default(None)
 	def get_poll(self, show: Show, episode: Episode):
-		self.q.execute("SELECT show, episode, poll_service, poll_id, timestamp, score FROM Polls WHERE show = ? AND episode = ?", (show.id, episode.number))
+		self.q.execute("SELECT show AS show_id, episode, poll_service AS service, poll_id AS id, timestamp AS date, score FROM Polls WHERE show = ? AND episode = ?", (show.id, episode.number))
 		poll = self.q.fetchone()
 		if poll is None:
 			return None
-		return Poll(*poll)
+		return Poll(**poll)
 
 	@db_error_default(list())
 	def get_polls(self, show: Show=None, missing_score=False):
 		polls = list()
 		if show is not None:
-			self.q.execute("SELECT show, episode, poll_service, poll_id, timestamp, score FROM Polls WHERE show = ?", (show.id,))
+			self.q.execute("SELECT show AS show_id, episode, poll_service AS service, poll_id AS id, timestamp AS date, score FROM Polls WHERE show = ?", (show.id,))
 		elif missing_score:
-			self.q.execute("SELECT show, episode, poll_service, poll_id, timestamp, score FROM Polls WHERE score is NULL AND show IN (SELECT id FROM Shows where enabled = 1)")
+			self.q.execute("SELECT show AS show_id, episode, poll_service AS service, poll_id AS id, timestamp AS date, score FROM Polls WHERE score is NULL AND show IN (SELECT id FROM Shows where enabled = 1)")
 		else:
 			error("Need to select a show to get polls")
 			return list()
 		for poll in self.q.fetchall():
-			polls.append(Poll(*poll))
+			polls.append(Poll(**poll))
 		return polls
 
 	# Searching
@@ -713,8 +718,8 @@ class DatabaseDatabase:
 				self.q.execute("SELECT show, name FROM ShowNames WHERE name = ? COLLATE alphanum", (name,))
 			matched = self.q.fetchall()
 			for match in matched:
-				debug("  Found match: {} | {}".format(match[0], match[1]))
-				shows.add(match[0])
+				debug("  Found match: {} | {}".format(match['show'], match['name']))
+				shows.add(match['show'])
 		return shows
 
 # Helper methods

--- a/src/data/models.py
+++ b/src/data/models.py
@@ -31,8 +31,6 @@ class DbEqMixin:
 
 class Show(DbEqMixin):
 	def __init__(self, id, name, name_en, length, show_type, has_source, is_nsfw, enabled, delayed):
-		# Note: arguments are order-sensitive
-		# Should probably be moved to keyword args, but not sure the best method on the database side
 		self.id = id
 		self.name = name
 		self.name_en = name_en
@@ -55,8 +53,7 @@ class Show(DbEqMixin):
 		return "Show: {} (id={}, type={}, len={})".format(self.name, self.id, self.type, self.length)
 
 class Episode:
-	def __init__(self, number, name, link, date):
-		# Note: arguments are order-sensitive
+	def __init__(self, number, name=None, link=None, date=None):
 		self.number = number
 		self.name = name		# Not stored in database
 		self.link = link
@@ -74,7 +71,7 @@ class Episode:
 		return now >= self.date
 
 class EpisodeScore:
-	def __init__(self, show_id, episode, site_id, score):
+	def __init__(self, show_id, episode, score, site_id=None):
 		self.show_id = show_id
 		self.episode = episode
 		self.site_id = site_id
@@ -82,7 +79,6 @@ class EpisodeScore:
 
 class Service(DbEqMixin):
 	def __init__(self, id, key, name, enabled, use_in_post):
-		# Note: arguments are order-sensitive
 		self.id = id
 		self.key = key
 		self.name = name
@@ -102,7 +98,6 @@ class Stream(DbEqMixin):
 			If a show should be numbered lower than 1 (ex. 0), display_offset should be negative.
 	"""
 	def __init__(self, id, service, show, show_id, show_key, name, remote_offset, display_offset, active):
-		# Note: arguments are order-sensitive
 		self.id = id
 		self.service = service
 		self.show = show
@@ -118,7 +113,7 @@ class Stream(DbEqMixin):
 	
 	@classmethod
 	def from_show(cls, show):
-		return Stream(-show.id, -1, show, show.id, show.name, show.name, 0, 0, 1)
+		return Stream(id=-show.id, service=-1, show=show, show_id=show.id, show_key=show.name, name=show.name, remote_offset=0, display_offset=0, active=1)
 	
 	def to_internal_episode(self, episode):
 		e = copy.copy(episode)
@@ -132,18 +127,16 @@ class Stream(DbEqMixin):
 
 class LinkSite(DbEqMixin):
 	def __init__(self, id, key, name, enabled):
-		# Note: arguments are order-sensitive
 		self.id = id
 		self.key = key
 		self.name = name
 		self.enabled = enabled == 1
 	
 	def __str__(self):
-		return "Link site: {} ({})".format(self.key, self.id, self.enabled)
+		return "Link site: {} {} ({})".format(self.key, self.id, self.enabled)
 
 class Link:
 	def __init__(self, site, show, site_key):
-		# Note: arguments are order-sensitive
 		self.site = site
 		self.show = show
 		self.site_key = site_key
@@ -180,7 +173,6 @@ class Poll:
 
 class LiteStream:
 	def __init__(self, show, service, service_name, url):
-		# Note: arguments are order-sensitive
 		self.show = show
 		self.service = service
 		self.service_name = service_name
@@ -190,19 +182,19 @@ class LiteStream:
 		return f"LiteStream: {self.service}|{self.service_name}, show={self.show}, url={self.url}"
 
 class UnprocessedShow:
-	def __init__(self, site_key, show_key, name, name_en, more_names, show_type, episode_count, has_source, is_nsfw):
+	def __init__(self, name, show_type, episode_count, has_source, is_nsfw=False, site_key=None, show_key=None, name_en=None, more_names=None):
 		self.site_key = site_key
 		self.show_key = show_key
 		self.name = name
 		self.name_en = name_en
-		self.more_names = more_names
+		self.more_names = more_names or []
 		self.show_type = show_type
 		self.episode_count = episode_count
 		self.has_source = has_source
 		self.is_nsfw = is_nsfw
 
 class UnprocessedStream:
-	def __init__(self, service_key, show_key, show_id, name, remote_offset, display_offset):
+	def __init__(self, service_key, show_key, remote_offset, display_offset, show_id=None, name=""):
 		self.service_key = service_key
 		self.show_key = show_key
 		self.show_id = show_id

--- a/src/module_batch_create.py
+++ b/src/module_batch_create.py
@@ -18,7 +18,7 @@ def main(config, db, show_name, episode_count):
 
 	post_urls = list()
 	for i in range(1, int_episode_count+1):
-		int_episode = Episode(i, None, None, None)
+		int_episode = Episode(number=i)
 		post_url = _create_reddit_post(config, db, show, stream, int_episode, submit=not config.debug)
 		info("  Post URL: {}".format(post_url))
 		if post_url is not None:
@@ -36,8 +36,8 @@ def main(config, db, show_name, episode_count):
 	if not config.debug:
 		megathread_post = reddit.submit_text_post(config.subreddit, megathread_title, megathread_body)
 	else:
-                megathread_post = None
-		
+		megathread_post = None
+
 	if megathread_post is not None:
 		debug("Post successful")
 		megathread_url = reddit.get_shortlink_from_id(megathread_post.id).replace("http:", "https:")
@@ -54,10 +54,10 @@ def main(config, db, show_name, episode_count):
 
 def _create_megathread_content(config, db, show, stream, episode_count):
 	title = _create_megathread_title(config, show, episode_count)
-	title = _format_post_text(config, db, title, config.post_formats, show, Episode(episode_count, None, None, None), stream)
+	title = _format_post_text(config, db, title, config.post_formats, show, Episode(number=episode_count), stream)
 	info("Title:\n"+title)
 
-	body = _format_post_text(config, db, config.batch_thread_post_body, config.post_formats, show, Episode(episode_count, None, None, None), stream)
+	body = _format_post_text(config, db, config.batch_thread_post_body, config.post_formats, show, Episode(number=episode_count), stream)
 	info("Body:\n"+body)
 	return title, body
 

--- a/src/module_create_threads.py
+++ b/src/module_create_threads.py
@@ -8,7 +8,7 @@ import reddit
 from module_find_episodes import _create_reddit_post, _edit_reddit_post
 
 def main(config, db, show_name, episode):
-	int_episode = Episode(int(episode), None, None, None)
+	int_episode = Episode(number=int(episode))
 	reddit.init_reddit(config)
 
 	show = db.get_show_by_name(show_name)

--- a/src/module_edit.py
+++ b/src/module_edit.py
@@ -42,7 +42,7 @@ def _edit_with_file(db, edit_file):
 			error("Invalid show type \"{}\"".format(stype))
 			return False
 		
-		show = UnprocessedShow(None, None, name, name_en, [], stype, length, has_source, is_nsfw)
+		show = UnprocessedShow(name=name, name_en=name_en, show_type=stype, episode_count=length, has_source=has_source, is_nsfw=is_nsfw)
 		found_ids = db.search_show_ids_by_names(name, exact=True)
 		debug("Found ids: {found_ids}")
 		if len(found_ids) == 0:
@@ -102,7 +102,7 @@ def _edit_with_file(db, edit_file):
 					debug("    id={}".format(show_key))
 					
 					if not db.has_stream(service_id, show_key):
-						s = UnprocessedStream(service_id, show_key, None, "", remote_offset, 0)
+						s = UnprocessedStream(service_key=service_id, show_key=show_key, remote_offset=remote_offset, display_offset=0)
 						db.add_stream(s, show_id, commit=False)
 					else:
 						service = db.get_service(key=service_id)

--- a/src/services/info/myanimelist.py
+++ b/src/services/info/myanimelist.py
@@ -45,7 +45,7 @@ class InfoHandler(AbstractInfoHandler):
 			id = child.find("id").text
 			name = child.find("title").text
 			more_names = [child.find("english").text]
-			show = UnprocessedShow(self.key, id, name, more_names, ShowType.UNKNOWN, 0, False)
+			show = UnprocessedShow(site_key=self.key, show_key=id, name=name, show_type=ShowType.UNKNOWN, episode_count=0, has_source=False, more_names=more_names)
 			shows.append(show)
 		
 		return shows
@@ -71,7 +71,7 @@ class InfoHandler(AbstractInfoHandler):
 		info("  English: {}".format(name_english))
 		
 		names = [name_english]
-		return UnprocessedShow(self.key, id, None, names, ShowType.UNKNOWN, 0, False)
+		return UnprocessedShow(site_key=self.key, show_key=show_id, name=None, show_type=ShowType.UNKNOWN, episode_count=0, has_source=False, more_names=names)
 	
 	def get_episode_count(self, link, **kwargs):
 		debug("Getting episode count")
@@ -150,7 +150,7 @@ class InfoHandler(AbstractInfoHandler):
 			episode_count = None if episode_count == "?" else int(episode_count)
 			has_source = show.find(class_="source").string != "Original"
 			
-			new_shows.append(UnprocessedShow(self.key, show_key, title, more_names, show_type, episode_count, has_source))
+			new_shows.append(UnprocessedShow(site_key=self.key, show_key=show_key, name=title, more_names=more_names, show_type=show_type, episode_count=episode_count, has_source=has_source))
 		
 		return new_shows
 	

--- a/src/services/stream/adultswim.py
+++ b/src/services/stream/adultswim.py
@@ -90,12 +90,12 @@ def _is_valid_episode(episode_data, show_key):
     date = datetime.fromordinal(dateutil.parser.parse(date_string).toordinal())
 
     if date > datetime.utcnow():
-	    return False
+        return False
 
     date_diff = datetime.utcnow() - date
     if date_diff >= timedelta(days=2):
-	    debug("  Episode too old")
-	    return False
+        debug("  Episode too old")
+        return False
 
     return True
 
@@ -109,4 +109,4 @@ def _digest_episode(feed_episode):
     date_string = feed_episode.find("meta", itemprop="dateCreated")["content"]
     date = datetime.fromordinal(dateutil.parser.parse(date_string).toordinal())
 
-    return Episode(num, name, link, date)
+    return Episode(number=num, name=name, link=link, date=date)

--- a/src/services/stream/crunchyroll.py
+++ b/src/services/stream/crunchyroll.py
@@ -126,7 +126,7 @@ class ServiceHandler(AbstractServiceHandler):
 				debug("  Key: {}".format(key))
 				remote_offset, display_offset = self._get_stream_info(key)
 				
-				raw_stream = UnprocessedStream(self.key, key, None, title, remote_offset, display_offset)
+				raw_stream = UnprocessedStream(service_key=self.key, show_key=key, remote_offset=remote_offset, display_offset=display_offset, name=title)
 				raw_streams.append(raw_stream)
 		
 		return raw_streams
@@ -203,7 +203,7 @@ def _digest_episode(feed_episode):
 	date = feed_episode.published_parsed
 	debug("  date={}".format(date))
 	
-	return Episode(num, name, link, date)
+	return Episode(number=num, name=name, link=link, date=date)
 
 _slug_regex = re.compile("crunchyroll.com/([a-z0-9-]+)/", re.I)
 

--- a/src/services/stream/hidive.py
+++ b/src/services/stream/hidive.py
@@ -135,4 +135,4 @@ def _digest_episode(feed_episode):
     link = episode_link
     date = datetime.utcnow() # Not included in stream !
 
-    return Episode(num, name, link, date)
+    return Episode(number=num, name=name, link=link, date=date)

--- a/src/services/stream/nyaa.py
+++ b/src/services/stream/nyaa.py
@@ -189,7 +189,7 @@ def _digest_episode(feed_episode):
 		debug("  Match found, num={}".format(episode_num))
 		date = feed_episode["published_parsed"] or datetime.utcnow()
 		link = feed_episode["id"]
-		return Episode(episode_num, None, link, date)
+		return Episode(number=episode_num, link=link, date=date)
 	debug("  No match found")
 	return None
 

--- a/src/services/stream/youtube.py
+++ b/src/services/stream/youtube.py
@@ -163,7 +163,7 @@ def _digest_episode(feed_episode):
 	date = datetime.fromisoformat(date_string) or datetime.utcnow()
 
 	link = _video_url.format(video_id=feed_episode["id"])
-	return Episode(episode_num, None, link, date)
+	return Episode(number=episode_num, link=link, date=date)
 
 def _extract_episode_num(name):
 	debug(f"Extracting episode number from \"{name}\"")
@@ -176,4 +176,4 @@ def _extract_episode_num(name):
 			debug(f"  Match found, num={num}")
 			return num
 	debug("  No match found")
-	return none
+	return None


### PR DESCRIPTION
I noticed the comment about having order-sensitive arguments in classes initialisation so I gave it a try: by changing row_factory to a dict you can pass the result of the query as kwargs with **

I assigned some default values as I saw fit based on the existing code; there is some naming mismatch between the tables and the class attributes, I used some aliases as I did not want to propose changes that would require altering the schema.

I think I adjusted all instances affected by this change; by the logs, the modules ``setup``, ``edit``, ``update``, and ``episode`` seemed to work as intended.