### PR TITLE
Add a YAML linting Github action

### DIFF
--- a/.github/config/.yamllint.yml
+++ b/.github/config/.yamllint.yml
@@ -1,0 +1,40 @@
+---
+# https://yamllint.readthedocs.io/en/stable/rules.html
+
+yaml-files:
+  - '*.yaml'
+  - '*.yml'
+  - '.yamllint'
+
+ignore:
+  - season_configs/template.yaml
+
+rules:
+  anchors: enable
+  braces: enable
+  brackets: enable
+  colons: enable
+  commas: enable
+  comments:
+    level: warning
+    min-spaces-from-content: 1
+  comments-indentation:
+    level: warning
+  document-end: disable
+  document-start:
+    level: warning
+  empty-lines: enable
+  empty-values: disable
+  float-values: disable
+  hyphens: enable
+  indentation: enable
+  key-duplicates: enable
+  key-ordering: disable
+  line-length: disable
+  new-line-at-end-of-file: enable
+  new-lines: enable
+  octal-values: disable
+  quoted-strings: disable
+  trailing-spaces: enable
+  truthy:
+    level: warning

--- a/.github/workflows/yaml_linter.yaml
+++ b/.github/workflows/yaml_linter.yaml
@@ -1,0 +1,18 @@
+---
+name: Yaml Linting
+on: # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - "*"
+  pull_request:
+    branches:
+      - "*"
+jobs:
+  YAML_Linting:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: YAML Linting
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          config_file: .github/config/.yamllint.yml

--- a/season_configs/fall_2016.yaml
+++ b/season_configs/fall_2016.yaml
@@ -319,7 +319,7 @@ info:
   anilist: ''
   mal: https://myanimelist.net/anime/31178/Uta_no%E2%98%86Prince-sama%E2%99%AA_Maji_Love_Legend_Star
 streams:
-  crunchyroll: '' #http://www.crunchyroll.com/uta-no-prince-sama
+  crunchyroll: '' # http://www.crunchyroll.com/uta-no-prince-sama
   funimation: ''
   daisuki: ''
 ---
@@ -379,7 +379,7 @@ info:
   anilist: ''
   mal: https://myanimelist.net/anime/33041/Bubuki_Buranki__Hoshi_no_Kyojin
 streams:
-  crunchyroll: '' #http://www.crunchyroll.com/bbkbrnk|12
+  crunchyroll: '' # http://www.crunchyroll.com/bbkbrnk|12
   funimation: ''
   daisuki: ''
 ---

--- a/season_configs/fall_2018.yaml
+++ b/season_configs/fall_2018.yaml
@@ -1,3 +1,4 @@
+---
 title: 'Akanesasu Shoujo'
 type: tv
 alias: ['The Girl in Twilight']

--- a/season_configs/fall_2019.yaml
+++ b/season_configs/fall_2019.yaml
@@ -1,3 +1,4 @@
+---
 title: 'Mini Yuri'
 alias: ['Yuru Yuri Shorts']
 has_source: true

--- a/season_configs/fall_2020.yaml
+++ b/season_configs/fall_2020.yaml
@@ -1,3 +1,4 @@
+---
 title: 'Higurashi no Naku Koro ni Gou [Reboot only thread]'
 alias: ['Higurashi: When They Cry - New']
 has_source: false

--- a/season_configs/fall_2021.yaml
+++ b/season_configs/fall_2021.yaml
@@ -1,3 +1,4 @@
+---
 title: '"Deji" Meets Girl'
 has_source: false
 info:
@@ -1343,28 +1344,4 @@ streams:
   hulu|Hulu: ''
   youtube: ''
   nyaa: ''
-#---
-#title: ''
-#alias: ['']
-#has_source: true
-#info:
-#  mal: ''
-#  anilist: ''
-#  anidb: ''
-#  kitsu: ''
-#  animeplanet: ''
-#  official: ''
-#  subreddit: ''
-#streams:
-#  crunchyroll: ''
-#  museasia: ''
-#  funimation|Funimation: ''
-#  wakanim|Wakanim: ''
-#  hidive: ''
-#  animelab|AnimeLab: ''
-#  bilibili|Bilibili: ''
-#  crunchyroll_nsfw|Crunchyroll: ''
-#  vrv|VRV: ''
-#  hulu|Hulu: ''
-#  youtube: ''
-#  nyaa: ''
+---

--- a/season_configs/fall_2022.yaml
+++ b/season_configs/fall_2022.yaml
@@ -1,3 +1,4 @@
+---
 title: '4-nin wa Sorezore Uso wo Tsuku'
 alias: ['The Little Lies We All Tell']
 has_source: true
@@ -1382,28 +1383,4 @@ streams:
   hulu|Hulu: ''
   youtube: ''
   nyaa: ''
-#---
-#title: ''
-#alias: ['']
-#has_source: true
-#info:
-#  mal: ''
-#  anilist: ''
-#  anidb: ''
-#  kitsu: ''
-#  animeplanet: ''
-#  official: ''
-#  subreddit: ''
-#streams:
-#  crunchyroll: ''
-#  museasia: ''
-#  funimation|Funimation: ''
-#  wakanim|Wakanim: ''
-#  hidive: ''
-#  animelab|AnimeLab: ''
-#  bilibili|Bilibili: ''
-#  crunchyroll_nsfw|Crunchyroll: ''
-#  vrv|VRV: ''
-#  hulu|Hulu: ''
-#  youtube: ''
-#  nyaa: ''
+---

--- a/season_configs/long.yaml
+++ b/season_configs/long.yaml
@@ -1,3 +1,4 @@
+---
 title: 'One Piece'
 has_source: true
 info:

--- a/season_configs/old.yaml
+++ b/season_configs/old.yaml
@@ -1,3 +1,4 @@
+---
 title: 'Meiken Lassie'
 alias: ['Famous Dog Lassie', 'Lassie Come-Home']
 has_source: true

--- a/season_configs/spring_2016.yaml
+++ b/season_configs/spring_2016.yaml
@@ -1,3 +1,4 @@
+---
 title: Anne Happy♪
 type: tv
 has_source: true
@@ -414,7 +415,7 @@ info:
     anilist: http://anilist.co/anime/21636/KagewaniShou
 streams:
     crunchyroll: ''
-    #Note: Crunchyroll hasn't updated the RSS feed with new episodes - http://www.crunchyroll.com/kagewani
+    # Note: Crunchyroll hasn't updated the RSS feed with new episodes - http://www.crunchyroll.com/kagewani
     funimation: ''
 ---
 title: Ansatsu Kyoushitsu 2nd Season
@@ -460,3 +461,4 @@ info:
 streams:
     crunchyroll: ''
     funimation: http://www.funimation.com/shows/rainbow-days|14
+---

--- a/season_configs/spring_2017.yaml
+++ b/season_configs/spring_2017.yaml
@@ -160,7 +160,7 @@ streams:
   crunchyroll: 'http://www.crunchyroll.com/kado-the-right-answer'
 ---
 title: 'Shuumatsu Nani Shitemasu ka? Isogashii desu ka? Sukutte Moratte Ii desu ka?'
-type: tv  
+type: tv
 has_source: true
 info:
   anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12238'

--- a/season_configs/spring_2018.yaml
+++ b/season_configs/spring_2018.yaml
@@ -1,3 +1,4 @@
+---
 title: 'Gundam Build Divers'
 type: tv
 has_source: false

--- a/season_configs/spring_2019.yaml
+++ b/season_configs/spring_2019.yaml
@@ -1,3 +1,4 @@
+---
 title: 'Bakumatsu: Crisis'
 alias: ['Bakumatsu Season 2']
 has_source: false

--- a/season_configs/spring_2020.yaml
+++ b/season_configs/spring_2020.yaml
@@ -1,3 +1,4 @@
+---
 title: 'Tamayomi'
 has_source: true
 info:
@@ -1117,29 +1118,4 @@ streams:
   amazon_uk|Amazon UK: ''
   primevideo|Prime Video International: ''
   nyaa: 'Great Pretender'
-#---
-#title: ''
-#alias: ['']
-#has_source: true
-#info:
-#  mal: ''
-#  anilist: ''
-#  anidb: ''
-#  kitsu: ''
-#  animeplanet: ''
-#  official: ''
-#  subreddit: ''
-#streams:
-#  crunchyroll: ''
-#  museasia: ''
-#  funimation|Funimation: ''
-#  wakanim|Wakanim: ''
-#  hidive: ''
-#  animelab|AnimeLab: ''
-#  crunchyroll_nsfw|Crunchyroll: ''
-#  vrv|VRV: ''
-#  hulu|Hulu: ''
-#  youtube: ''
-#  amazon|Amazon US: ''
-#  amazon_uk|Amazon UK: ''
-#  primevideo|Prime Video International: ''
+---

--- a/season_configs/spring_2021.yaml
+++ b/season_configs/spring_2021.yaml
@@ -1,3 +1,4 @@
+---
 title: '86 EIGHTY-SIX'
 has_source: true
 info:
@@ -507,7 +508,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/gloomy-the-naughty-grizzly'
   official: 'https://gloomy-official.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/gloomy-the-naughty-grizzly'
   museasia: ''
   anione: ''
@@ -1508,27 +1509,4 @@ streams:
   hulu|Hulu: ''
   youtube: ''
   nyaa: ''
-#---
-#title: ''
-#alias: ['']
-#has_source: true
-#info:
-#  mal: ''
-#  anilist: ''
-#  anidb: ''
-#  kitsu: ''
-#  animeplanet: ''
-#  official: ''
-#  subreddit: ''
-#streams:
-#  crunchyroll: ''
-#  museasia: ''
-#  funimation|Funimation: ''
-#  wakanim|Wakanim: ''
-#  hidive: ''
-#  animelab|AnimeLab: ''
-#  crunchyroll_nsfw|Crunchyroll: ''
-#  vrv|VRV: ''
-#  hulu|Hulu: ''
-#  youtube: ''
-#  nyaa: ''
+---

--- a/season_configs/spring_2022.yaml
+++ b/season_configs/spring_2022.yaml
@@ -1,3 +1,4 @@
+---
 title: 'Aoashi'
 has_source: true
 info:
@@ -1475,28 +1476,4 @@ streams:
     youtube: ''
     netflix|Netflix: 'https://www.netflix.com/title/81030224'
     nyaa: ''
-#---
-#title: ''
-#alias: ['']
-#has_source: true
-#info:
-#  mal: ''
-#  anilist: ''
-#  anidb: ''
-#  kitsu: ''
-#  animeplanet: ''
-#  official: ''
-#  subreddit: ''
-#streams:
-#  crunchyroll: ''
-#  museasia: ''
-#  funimation|Funimation: ''
-#  wakanim|Wakanim: ''
-#  hidive: ''
-#  animelab|AnimeLab: ''
-#  bilibili|Bilibili: ''
-#  crunchyroll_nsfw|Crunchyroll: ''
-#  vrv|VRV: ''
-#  hulu|Hulu: ''
-#  youtube: ''
-#  nyaa: ''
+---

--- a/season_configs/spring_2023.yaml
+++ b/season_configs/spring_2023.yaml
@@ -1,3 +1,4 @@
+---
 title: 'Alice Gear Aegis Expansion'
 title_en: ""
 has_source: true
@@ -1531,29 +1532,4 @@ streams:
   disney|Disney: ''
   youtube: ''
   nyaa: ''
-#---
-#title: ''
-#title_en: ''
-#alias: ['']
-#has_source: true
-#info:
-#  mal: ''
-#  anilist: ''
-#  anidb: ''
-#  kitsu: ''
-#  animeplanet: ''
-#  official: ''
-#  subreddit: ''
-#streams:
-#  crunchyroll: ''
-#  museasia: ''
-#  funimation|Funimation: ''
-#  wakanim|Wakanim: ''
-#  hidive: ''
-#  animelab|AnimeLab: ''
-#  bilibili|Bilibili: ''
-#  crunchyroll_nsfw|Crunchyroll: ''
-#  vrv|VRV: ''
-#  hulu|Hulu: ''
-#  youtube: ''
-#  nyaa: ''
+---

--- a/season_configs/summer_2016.yaml
+++ b/season_configs/summer_2016.yaml
@@ -1,6 +1,7 @@
+---
 # Funimation shows without URLs:
 #   Danganronpa 3 (both shows on the same URL?)
-# 
+#
 # Missing shows:
 #   ReLIFE - all episodes aired at once ._.
 #   Momokuri - re-airing, airing two episodes at a time
@@ -279,15 +280,15 @@ info:
 streams:
     crunchyroll: http://www.crunchyroll.com/mob-psycho-100
     funimation: ''
-#---
-#title: Momokuri
-#type: tv
-#has_source: true
-#info:
+# ---
+# title: Momokuri
+# type: tv
+# has_source: true
+# info:
 #    mal: http://myanimelist.net/anime/30014/Momokuri
 #    anidb: http://anidb.net/perl-bin/animedb.pl?show=anime&aid=11073
 #    anilist: http://anilist.co/anime/21841/momokuri(TV)
-#streams:
+# streams:
 #    crunchyroll: ''
 #    funimation: ''
 ---

--- a/season_configs/summer_2018.yaml
+++ b/season_configs/summer_2018.yaml
@@ -1,3 +1,4 @@
+---
 title: 'Aguu: Tensai Ningyou'
 type: tv
 info:
@@ -95,8 +96,8 @@ info:
   anidb: 'https://anidb.net/perl-bin/animedb.pl?show=anime&aid=12023'
   kitsu: 'https://kitsu.io/anime/flcl-progressive'
   official: 'http://flcl-anime.com/'
-#streams:
-#  adultswim|Adult Swim: 'http://www.adultswim.com/videos/flcl/'
+# streams:
+# adultswim|Adult Swim: 'http://www.adultswim.com/videos/flcl/'
 ---
 title: 'FLCL Alternative'
 type: tv

--- a/season_configs/summer_2019.yaml
+++ b/season_configs/summer_2019.yaml
@@ -1,3 +1,4 @@
+---
 title: 'Starmyu Season 3'
 alias: ['Koukou Hoshi Kageki', 'High School Star Musical', 'Star Mu']
 has_source: false

--- a/season_configs/summer_2020.yaml
+++ b/season_configs/summer_2020.yaml
@@ -1,3 +1,4 @@
+---
 title: 'Dokyuu Hentai HxEros'
 alias: ['Super HxEros', 'Uncensored version on Wednesday']
 has_source: true
@@ -518,29 +519,4 @@ streams:
   amazon|Amazon US: ''
   amazon_uk|Amazon UK: ''
   primevideo|Prime Video International: ''
-#---
-#title: ''
-#alias: ['']
-#has_source: true
-#info:
-#  mal: ''
-#  anilist: ''
-#  anidb: ''
-#  kitsu: ''
-#  animeplanet: ''
-#  official: ''
-#  subreddit: ''
-#streams:
-#  crunchyroll: ''
-#  museasia: ''
-#  funimation|Funimation: ''
-#  wakanim|Wakanim: ''
-#  hidive: ''
-#  animelab|AnimeLab: ''
-#  crunchyroll_nsfw|Crunchyroll: ''
-#  vrv|VRV: ''
-#  hulu|Hulu: ''
-#  youtube: ''
-#  amazon|Amazon US: ''
-#  amazon_uk|Amazon UK: ''
-#  primevideo|Prime Video International: ''
+---

--- a/season_configs/summer_2021.yaml
+++ b/season_configs/summer_2021.yaml
@@ -1,3 +1,4 @@
+---
 title: '100-man no Inochi no Ue ni Ore wa Tatte Iru 2nd Season'
 alias: ["I'm Standing on a Million Lives Season 2"]
 has_source: true
@@ -9,7 +10,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/im-standing-on-a-million-lives-2nd-season'
   official: 'http://1000000-lives.com/'
   subreddit: '/r/100ManNoInochi'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/im-standing-on-a-million-lives|12'
   museasia: ''
   anione: ''
@@ -32,7 +33,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/assault-lily-fruits'
   official: 'https://anime.assaultlily-pj.com/'
   subreddit: '/r/AssaultLily'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -56,7 +57,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/bokutachi-no-remake'
   official: 'https://bokurema.com/'
   subreddit: '/r/BokutachiNoRemake'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/remake-our-life'
   museasia: ''
   anione: 'https://www.youtube.com/playlist?list=PLxSscENEp7Jjad7wjjOwOoFgbHC5ZXhtG'
@@ -80,7 +81,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/cheat-kusushi-no-slow-life'
   official: 'https://www.cheat-kusushi.jp/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/drug-store-in-another-world-the-slow-life-of-a-cheat-pharmacist'
   museasia: ''
   anione: ''
@@ -104,7 +105,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/dcide-traumerei-the-animation'
   official: 'https://dctm-pj.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/d_cide-traumerei-the-animation'
   museasia: ''
   anione: ''
@@ -128,7 +129,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/deatte-5-byou-de-battle'
   official: 'https://dea5-anime.com/'
   subreddit: '/r/BattleGamein5Seconds'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/battle-game-in-5-seconds'
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl0xUFXsv7l59J4AMJoSBD19'
   anione: ''
@@ -152,7 +153,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/how-a-realist-hero-rebuilt-the-kingdom'
   official: 'https://genkoku-anime.com/'
   subreddit: '/r/RealistHero'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/how-a-realist-hero-rebuilt-the-kingdom'
   museasia: ''
   anione: ''
@@ -175,7 +176,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/getter-robo-arc'
   official: 'https://getterrobot-arc.com/'
   subreddit: '/r/getterrobo'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: 'https://www.youtube.com/playlist?list=PLxSscENEp7JhHilZTy4u4rr_s8-nEM1-8'
@@ -199,7 +200,7 @@ info:
   animeplanet: ''
   official: 'https://anime-hachinai.com/'
   subreddit: '/r/CinderellaNine'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -223,7 +224,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/heion-sedai-no-idaten-tachi'
   official: 'https://idaten-anime.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll_nsfw|Crunchyroll: 'https://www.crunchyroll.com/the-idaten-deities-know-only-peace'
   museasia: ''
   anione: ''
@@ -247,7 +248,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/higurashi-when-they-cry-sotsu'
   official: 'https://higurashianime.com/'
   subreddit: '/r/Higurashinonakakoroni'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: 'https://www.youtube.com/playlist?list=PLxSscENEp7Jh7yn1GT-SfcTUqt5B_A7wf'
@@ -271,7 +272,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/idolish7-3'
   official: 'http://idolish7.com/aninana/'
   subreddit: '/r/IDOLiSH7'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/idolish7'
   museasia: ''
   anione: ''
@@ -295,7 +296,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/the-great-jahy-will-not-be-defeated'
   official: 'https://jahysama-anime.com/'
   subreddit: '/r/JahySamaWaKujikenai'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/the-great-jahy-will-not-be-defeated'
   museasia: ''
   anione: ''
@@ -319,7 +320,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/kageki-shoujo'
   official: 'https://kageki-anime.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -343,7 +344,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/kanojo-mo-kanojo'
   official: 'https://kanokano-anime.com/'
   subreddit: '/r/KanojoMoKanojo'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/girlfriend-girlfriend'
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl31SiYBPaDaekqPOjqvl2Qg'
   anione: ''
@@ -366,7 +367,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/kick-and-slide'
   official: 'https://www.kidsbhappy.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -390,7 +391,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/miss-kobayashis-dragon-maid-s'
   official: 'https://maidragon.jp/2nd/'
   subreddit: '/r/DragonMaid'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/miss-kobayashis-dragon-maid'
   museasia: ''
   anione: ''
@@ -413,7 +414,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/love-live-superstar'
   official: 'http://www.lovelive-anime.jp/yuigaoka/'
   subreddit: '/r/LoveLive'
-streams: 
+streams:
   crunchyroll_regionlocked|Crunchyroll: 'https://www.crunchyroll.com/love-live-superstar'
   museasia: ''
   anione: ''
@@ -437,7 +438,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/magia-record-puella-magi-madoka-magica-side-story-2nd-season'
   official: 'https://anime.magireco.com/'
   subreddit: '/r/magiarecord'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/magia-record-puella-magi-madoka-magica-side-story|13'
   museasia: ''
   anione: ''
@@ -461,7 +462,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/the-honor-student-at-magic-high-school'
   official: 'https://mahouka-yuutousei.jp/'
   subreddit: '/r/Mahouka'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -485,7 +486,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/megami-ryou-no-ryoubo-kun'
   official: 'https://megamiryou.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -509,7 +510,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/megaton-musashi'
   official: 'http://www.megaton-musashi.jp/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -533,7 +534,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/the-dungeon-of-the-black-company'
   official: 'https://meikyubc-anime.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -555,8 +556,8 @@ info:
   kitsu: 'https://kitsu.io/anime/43894'
   animeplanet: 'http://www.anime-planet.com/anime/night-head-2041'
   official: 'https://nighthead2041.jp/'
-  subreddit: '' # /r/NIGHTHEAD2041 - unmoderated.
-streams: 
+  subreddit: '' #  /r/NIGHTHEAD2041 - unmoderated.
+streams:
   crunchyroll: 'https://www.crunchyroll.com/night-head-2041'
   museasia: ''
   anione: ''
@@ -580,7 +581,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/ore-tsushima'
   official: 'https://www.tsushima-anime.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: ''
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl31ypf0OGfmtqZ5upkdcrGt'
   youtube: 'https://www.youtube.com/playlist?list=PLl7reuZgwQ_TGFBlOPAm59WvVTXBPAufB'
@@ -591,7 +592,6 @@ streams:
   animelab|AnimeLab: ''
   vrv|VRV: ''
   hulu|Hulu: ''
-  youtube: ''
   nyaa: ''
 ---
 title: 'Otome Game no Hametsu Flag shika Nai Akuyaku Reijou ni Tensei shite Shimatta… X'
@@ -605,7 +605,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/my-next-life-as-a-villainess-all-routes-lead-to-doom-season-2'
   official: 'https://hamehura-anime.com/'
   subreddit: '/r/Otomegame'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/my-next-life-as-a-villainess-all-routes-lead-to-doom'
   museasia: ''
   anione: ''
@@ -628,7 +628,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/peach-boy-riverside'
   official: 'https://peachboyriverside.com/'
   subreddit: '/r/PeachBoyRiverside'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/peach-boy-riverside'
   museasia: ''
   anione: ''
@@ -651,7 +651,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/pretty-all-friends-selection'
   official: 'https://www.takaratomy-arts.co.jp/specials/pretty10th/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -674,7 +674,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/re-main'
   official: 'https://re-main.net/'
   subreddit: '/r/Re_Main'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: 'https://www.youtube.com/playlist?list=PLxSscENEp7JhnfTQGx_aB4V2B6mc6a3gx'
@@ -697,7 +697,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/scarlet-nexus'
   official: 'https://snx-anime.net/'
   subreddit: '/r/ScarletNexus'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: 'https://www.youtube.com/playlist?list=PLxSscENEp7Jg9olNs9aYTSFjc6PM5vrbU'
@@ -721,7 +721,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/seirei-gensouki-spirit-chronicles'
   official: 'https://seireigensouki.com/'
   subreddit: '/r/SeireiGensouki'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/seirei-gensouki-spirit-chronicles'
   museasia: ''
   anione: ''
@@ -745,7 +745,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/shinigami-bocchan-to-kuro-maid'
   official: 'https://bocchan-anime.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -769,7 +769,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/shiroi-suna-no-aquatope'
   official: 'https://aquatope-anime.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/the-aquatope-on-white-sand'
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl13ebVE0dgagqzozYJ5d1Er'
   anione: ''
@@ -792,7 +792,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/sonny-boy'
   official: 'https://anime.shochiku.co.jp/sonny-boy/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -815,7 +815,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/tsukipro-the-animation-2'
   official: 'http://tsukipro-anime.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -839,7 +839,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/tantei-wa-mou-shindeiru'
   official: 'https://tanmoshi-anime.jp/'
   subreddit: '/r/DetectiveAlreadyDead'
-streams: 
+streams:
   crunchyroll: ''
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl2qyiTb5d4rLdPpMLM8gEGP'
   anione: ''
@@ -863,7 +863,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/tensei-shitara-slime-datta-ken-2nd-season-part-2'
   official: 'https://www.ten-sura.com/anime/tensura'
   subreddit: '/r/TenseiSlime'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/that-time-i-got-reincarnated-as-a-slime|36'
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl24o1N6adcgGPyIJPfJ21GL'
   anione: ''
@@ -887,7 +887,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/tsukimichi-moonlit-fantasy'
   official: 'https://tsukimichi.com/'
   subreddit: '/r/TsukiMichi'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/tsukimichi-moonlit-fantasy-'
   museasia: ''
   anione: ''
@@ -911,7 +911,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/uramichi-oniisan'
   official: 'http://uramichi-anime.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -935,7 +935,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/the-case-study-of-vanitas'
   official: 'https://vanitas-anime.com/'
   subreddit: '/r/vanitasnocarte'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -959,7 +959,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/yamishibai-japanese-ghost-stories-9th-season'
   official: 'https://www.tv-tokyo.co.jp/anime/yamishibai9/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/theatre-of-darkness-yamishibai'
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl0B5qey1i3WQhE7vhhtXINb'
   anione: ''
@@ -982,7 +982,7 @@ info:
   animeplanet: 'https://www.anime-planet.com/anime/obey-me'
   official: 'https://twitter.com/ObeyMeOfficial1'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -999,72 +999,48 @@ title: 'Ore, Tsushima'
 alias: ['I, Tsushima']
 has_source: true
 info:
- mal: 'https://myanimelist.net/anime/48252'
- anilist: 'https://anilist.co/anime/130392/Ore-Tsushima/'
- anidb: 'https://anidb.net/anime/16071'
- kitsu: 'https://kitsu.io/anime/ore-tsushima'
- animeplanet: 'https://www.anime-planet.com/anime/ore-tsushima'
- official: ''
- subreddit: ''
+  mal: 'https://myanimelist.net/anime/48252'
+  anilist: 'https://anilist.co/anime/130392/Ore-Tsushima/'
+  anidb: 'https://anidb.net/anime/16071'
+  kitsu: 'https://kitsu.io/anime/ore-tsushima'
+  animeplanet: 'https://www.anime-planet.com/anime/ore-tsushima'
+  official: ''
+  subreddit: ''
 streams:
- crunchyroll: ''
- youtube: 'https://www.youtube.com/playlist?list=PLl7reuZgwQ_TGFBlOPAm59WvVTXBPAufB'
- museasia: ''
- funimation|Funimation: ''
- wakanim|Wakanim: ''
- hidive: ''
- animelab|AnimeLab: ''
- crunchyroll_nsfw|Crunchyroll: ''
- vrv|VRV: ''
- hulu|Hulu: ''
- youtube: ''
- nyaa: ''
+  crunchyroll: ''
+  youtube: 'https://www.youtube.com/playlist?list=PLl7reuZgwQ_TGFBlOPAm59WvVTXBPAufB'
+  museasia: ''
+  funimation|Funimation: ''
+  wakanim|Wakanim: ''
+  hidive: ''
+  animelab|AnimeLab: ''
+  crunchyroll_nsfw|Crunchyroll: ''
+  vrv|VRV: ''
+  hulu|Hulu: ''
+  nyaa: ''
 ---
 title: 'Kaizoku Oujo'
 alias: ['Fena: Pirate Princess']
 has_source: false
 info:
- mal: 'https://myanimelist.net/anime/42544'
- anilist: 'https://anilist.co/anime/122052/Kaizoku-Oujo/'
- anidb: 'https://anidb.net/anime/15656'
- kitsu: 'https://kitsu.io/anime/43456'
- animeplanet: 'https://www.anime-planet.com/anime/fena-pirate-princess'
- official: 'http://fena-pirate-princess.com/'
- subreddit: '/r/KaizokuOujo'
+  mal: 'https://myanimelist.net/anime/42544'
+  anilist: 'https://anilist.co/anime/122052/Kaizoku-Oujo/'
+  anidb: 'https://anidb.net/anime/15656'
+  kitsu: 'https://kitsu.io/anime/43456'
+  animeplanet: 'https://www.anime-planet.com/anime/fena-pirate-princess'
+  official: 'http://fena-pirate-princess.com/'
+  subreddit: '/r/KaizokuOujo'
 streams:
- crunchyroll: 'https://www.crunchyroll.com/fena-pirate-princess'
- adultswim: 'https://www.adultswim.com/videos/fena-pirate-princess'
- museasia: ''
- funimation|Funimation: ''
- wakanim|Wakanim: ''
- hidive: ''
- animelab|AnimeLab: ''
- crunchyroll_nsfw|Crunchyroll: ''
- vrv|VRV: 'https://vrv.co/series/GZJH3DPM1'
- hulu|Hulu: ''
- youtube: ''
- nyaa: ''
-#---
-#title: ''
-#alias: ['']
-#has_source: true
-#info:
-#  mal: ''
-#  anilist: ''
-#  anidb: ''
-#  kitsu: ''
-#  animeplanet: ''
-#  official: ''
-#  subreddit: ''
-#streams:
-#  crunchyroll: ''
-#  museasia: ''
-#  funimation|Funimation: ''
-#  wakanim|Wakanim: ''
-#  hidive: ''
-#  animelab|AnimeLab: ''
-#  crunchyroll_nsfw|Crunchyroll: ''
-#  vrv|VRV: ''
-#  hulu|Hulu: ''
-#  youtube: ''
-#  nyaa: ''
+  crunchyroll: 'https://www.crunchyroll.com/fena-pirate-princess'
+  adultswim: 'https://www.adultswim.com/videos/fena-pirate-princess'
+  museasia: ''
+  funimation|Funimation: ''
+  wakanim|Wakanim: ''
+  hidive: ''
+  animelab|AnimeLab: ''
+  crunchyroll_nsfw|Crunchyroll: ''
+  vrv|VRV: 'https://vrv.co/series/GZJH3DPM1'
+  hulu|Hulu: ''
+  youtube: ''
+  nyaa: ''
+---

--- a/season_configs/summer_2022.yaml
+++ b/season_configs/summer_2022.yaml
@@ -1,3 +1,4 @@
+---
 title: '5-Okunen Button ~Sota Sugahara no Short Short~'
 has_source: true
 info:
@@ -1280,28 +1281,4 @@ streams:
   disney|Disney: ''
   youtube: ''
   nyaa: ''
-#---
-#title: ''
-#alias: ['']
-#has_source: true
-#info:
-#  mal: ''
-#  anilist: ''
-#  anidb: ''
-#  kitsu: ''
-#  animeplanet: ''
-#  official: ''
-#  subreddit: ''
-#streams:
-#  crunchyroll: ''
-#  museasia: ''
-#  funimation|Funimation: ''
-#  wakanim|Wakanim: ''
-#  hidive: ''
-#  animelab|AnimeLab: ''
-#  bilibili|Bilibili: ''
-#  crunchyroll_nsfw|Crunchyroll: ''
-#  vrv|VRV: ''
-#  hulu|Hulu: ''
-#  youtube: ''
-#  nyaa: ''
+---

--- a/season_configs/template.yaml
+++ b/season_configs/template.yaml
@@ -1,0 +1,27 @@
+#---
+#title: ''
+#title_en: ''
+#alias: ['']
+#has_source: true
+#info:
+#  mal: ''
+#  anilist: ''
+#  anidb: ''
+#  kitsu: ''
+#  animeplanet: ''
+#  official: ''
+#  subreddit: ''
+#streams:
+#  crunchyroll: ''
+#  museasia: ''
+#  funimation|Funimation: ''
+#  wakanim|Wakanim: ''
+#  hidive: ''
+#  animelab|AnimeLab: ''
+#  bilibili|Bilibili: ''
+#  crunchyroll_nsfw|Crunchyroll: ''
+#  vrv|VRV: ''
+#  hulu|Hulu: ''
+#  youtube: ''
+#  nyaa: ''
+---

--- a/season_configs/winter_2019.yaml
+++ b/season_configs/winter_2019.yaml
@@ -1,3 +1,4 @@
+---
 title: '3D Kanojo: Real Girl Season 2'
 alias: ['3D Girlfriend']
 has_source: true

--- a/season_configs/winter_2020.yaml
+++ b/season_configs/winter_2020.yaml
@@ -1,3 +1,4 @@
+---
 title: 'Somali to Mori no Kamisama'
 alias: ['Somali and the Forest Spirit']
 has_source: true
@@ -1007,7 +1008,6 @@ streams:
   amazon|Amazon US: ''
   amazon_uk|Amazon UK: ''
   primevideo|Prime Video International: ''
-  primevideo|Prime Video International: ''
 ---
 title: 'IDOLiSH7: Second Beat!'
 alias: ['Idolish Seven Season 2']
@@ -1085,29 +1085,4 @@ streams:
   amazon|Amazon US: ''
   amazon_uk|Amazon UK: ''
   primevideo|Prime Video International: ''
-#---
-#title: ''
-#alias: ['']
-#has_source: true
-#info:
-#  mal: ''
-#  anilist: ''
-#  anidb: ''
-#  kitsu: ''
-#  animeplanet: ''
-#  official: ''
-#  subreddit: ''
-#streams:
-#  crunchyroll: ''
-#  museasia: ''
-#  funimation|Funimation: ''
-#  wakanim|Wakanim: ''
-#  hidive: ''
-#  animelab|AnimeLab: ''
-#  crunchyroll_nsfw|Crunchyroll: ''
-#  vrv|VRV: ''
-#  hulu|Hulu: ''
-#  youtube: ''
-#  amazon|Amazon US: ''
-#  amazon_uk|Amazon UK: ''
-#  primevideo|Prime Video International: ''
+---

--- a/season_configs/winter_2021.yaml
+++ b/season_configs/winter_2021.yaml
@@ -1,3 +1,4 @@
+---
 title: '2.43: Seiin Koukou Danshi Volley-bu'
 alias: ['2.43: Seiin High School Boys Volleyball Team']
 has_source: true
@@ -9,7 +10,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/243-seiin-koukou-danshi-volley-bu'
   official: 'https://243anime.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -32,7 +33,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/abciee-shuugyou-nikki'
   official: 'https://abciee.abc-anime.co.jp/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/abciee-working-diary'
   museasia: ''
   anione: 'https://www.youtube.com/playlist?list=PLxSscENEp7JhnjCV8G6KU3crrzcVVpHpI'
@@ -54,7 +55,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/aikatsu-planet'
   official: 'http://www.aikatsu.net/'
   subreddit: '/r/aikatsu/'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -77,7 +78,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/azur-lane-bisoku-zenshin'
   official: 'https://azurlane-bisoku.jp/'
   subreddit: '/r/AzureLane'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/anime-azurlane-slow-ahead'
   museasia: ''
   anione: ''
@@ -100,7 +101,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/azur-lane-bisoku-zenshin'
   official: 'https://azurlane-bisoku.jp/'
   subreddit: '/r/AzureLane/'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/anime-azurlane-slow-ahead'
   museasia: ''
   anione: ''
@@ -123,7 +124,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/back-arrow'
   official: 'https://back-arrow.com/'
   subreddit: '/r/BackArrow'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -145,7 +146,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/beastars-2'
   official: 'https://bst-anime.com/'
   subreddit: '/r/Beastars'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -167,7 +168,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/bungou-stray-dogs-wan'
   official: 'https://bungo-stray-dogs-wan.com/'
   subreddit: '/r/BungouStrayDogs'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/bungo-strays-dogs-wan'
   museasia: ''
   anione: ''
@@ -190,7 +191,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/dr-stone-stone-wars'
   official: 'https://dr-stone.jp/'
   subreddit: '/r/DrStone'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/dr-stone'
   museasia: ''
   anione: ''
@@ -212,7 +213,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/ex-arm'
   official: 'https://www.exarm-anime.com/'
   subreddit: '/r/ExArm'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/ex-arm'
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl0ndzzvMI7DSXcS1PT1VJYa'
   anione: ''
@@ -234,7 +235,7 @@ info:
   animeplanet: ''
   official: 'https://anime.fate-go.jp/fgc/'
   subreddit: '/r/grandorder'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -256,7 +257,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/gekidol'
   official: 'http://www.gekidol.com/'
   subreddit: '/r/Gekidol'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -279,7 +280,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/the-quintessential-quintuplets-2nd-season'
   official: 'http://www.tbs.co.jp/anime/5hanayome/'
   subreddit: '/r/5ToubunNoHanayome'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/the-quintessential-quintuplets'
   museasia: ''
   anione: ''
@@ -302,7 +303,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/cells-at-work-code-black'
   official: 'https://saibou-black.com/'
   subreddit: '/r/CellsAtWork'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -325,7 +326,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/cells-at-work-2'
   official: 'http://hataraku-saibou.com/'
   subreddit: '/r/CellsAtWork'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -347,7 +348,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/horimiya'
   official: 'https://horimiya-anime.com/'
   subreddit: '/r/Horimiya'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -369,7 +370,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/hortensia-saga'
   official: 'https://animehorsaga.jp/'
   subreddit: '/r/hortensia_saga'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -392,7 +393,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/idolls'
   official: 'https://wsy-idolls.com/anime'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/idolls'
   museasia: ''
   anione: ''
@@ -414,7 +415,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/idoly-pride'
   official: 'https://anime.idolypride.jp/'
   subreddit: '/r/IdolyPride'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -437,7 +438,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/i-chu-etoile-stage'
   official: 'https://etoile-anime.jp/'
   subreddit: '/r/ichu'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/ichu'
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl3lkMqeu3M0PaNttQM0cWka'
   anione: ''
@@ -460,7 +461,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/bottom-tier-character-tomozaki'
   official: 'http://tomozaki-koushiki.com/'
   subreddit: '/r/Tomozaki_kun'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -483,7 +484,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/dr-ramune-mysterious-disease-specialist'
   official: 'https://ramune-anime.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/dr-ramune-mysterious-disease-specialist-'
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl2ZFZlTclIzJrxs74_7Nb47'
   anione: ''
@@ -506,7 +507,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/kaifuku-jutsushi-no-yarinaoshi'
   official: 'http://kaiyari.com/'
   subreddit: '/r/RedoOfHealer'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -528,7 +529,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/kemono-jihen'
   official: 'https://kemonojihen-anime.com/'
   subreddit: '/r/KemonoJihen'
-streams: 
+streams:
   crunchyroll: ''
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl1YS_pINBRcstuSCSgO4EGj'
   anione: ''
@@ -550,7 +551,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/kintamani-dog'
   official: 'https://kintamani-dog.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -573,7 +574,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/kumo-desu-ga-nanika'
   official: 'https://kumo-anime.com/'
   subreddit: '/r/KumoDesu'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/so-im-a-spider-so-what'
   museasia: ''
   anione: 'https://www.youtube.com/playlist?list=PLxSscENEp7Jh0Urq4XJv3SkmYTq-goyCo'
@@ -596,7 +597,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/log-horizon-entaku-houkai'
   official: 'https://www6.nhk.or.jp/anime/program/detail.html?i=loghorizon3'
   subreddit: '/r/LogHorizon'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -619,7 +620,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/maiko-san-chi-no-makanai-san'
   official: 'https://www6.nhk.or.jp/anime/special/special.html?i=8132'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/kiyo-in-kyoto-from-the-maiko-house'
   museasia: ''
   anione: ''
@@ -642,7 +643,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/sorcerous-stabber-orphen-2'
   official: 'http://ssorphen-anime.com/'
   subreddit: '/r/MajutsushiOrphen'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -665,7 +666,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/mushoku-tensei-jobless-reincarnation'
   official: 'https://mushokutensei.jp/'
   subreddit: '/r/mushokutensei'
-streams: 
+streams:
   crunchyroll: ''
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl01_ftoIT3birJWkpxFZkEl'
   anione: ''
@@ -688,7 +689,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/the-seven-deadly-sins-angers-judgement'
   official: 'https://www.7-taizai.net/'
   subreddit: '/r/NanatsunoTaizai'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -711,7 +712,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/non-non-biyori-3rd-season'
   official: 'https://nonnontv.com/tvanime/'
   subreddit: '/r/Non_Non_Biyori'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/non-non-biyori'
   museasia: ''
   anione: ''
@@ -734,7 +735,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/okashi-na-sabaku-no-suna-to-manu'
   official: 'https://suna-manu.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -757,7 +758,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/ore-dake-haireru-kakushi-dungeon-kossori-kitaete-sekai-saikyou'
   official: 'https://kakushidungeon-anime.jp/'
   subreddit: '/r/HiddenDungeon'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/the-hidden-dungeon-only-i-can-enter'
   museasia: ''
   anione: ''
@@ -780,7 +781,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/otona-no-bouguya-san-2nd-season'
   official: 'https://ganma.jp/g/anime/otonabougu/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/armor-shop-for-ladies-gentlemen'
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl3hB6k5qSdSH296aVdctz8V'
   anione: ''
@@ -803,7 +804,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/project-scard-praeter-no-kizu'
   official: 'https://project-scard.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: ''
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl2AAB1zAh5bCOdsxuBznXFl'
   anione: ''
@@ -826,7 +827,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/re-zero-starting-life-in-another-world-season-2-part-ii'
   official: 'http://re-zero-anime.jp/tv/'
   subreddit: '/r/Re_Zero'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/rezero-starting-life-in-another-world-'
   museasia: ''
   anione: ''
@@ -849,7 +850,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/sk8-the-infinity'
   official: 'https://sk8-project.com/'
   subreddit: '/r/SK8TheInfinity'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -872,7 +873,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/true-cooking-master-boy-2nd-season'
   official: 'http://cookingmaster-anime.jp/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/true-cooking-master-boy'
   museasia: ''
   anione: ''
@@ -894,7 +895,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/show-by-rock-stars'
   official: 'https://showbyrock-anime-s.com/'
   subreddit: '/r/ShowByRock'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: 'https://www.youtube.com/playlist?list=PLxSscENEp7Jg-H3LCLflZvXPqNzBBcgPe'
@@ -917,7 +918,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/skate-leading-stars'
   official: 'https://skateleadingstars.com/'
   subreddit: '/r/SkateLeadingStars'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: 'https://www.youtube.com/playlist?list=PLxSscENEp7JhI_jQt9Ivtl_N_rDOaSQyU'
@@ -940,7 +941,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/soukou-musume'
   official: 'http://soukou-musume-senki.com/'
   subreddit: '/r/lbx'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -963,7 +964,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/suppose-a-kid-from-the-last-dungeon-boonies-moved-to-a-starter-town'
   official: 'https://lasdan.com/'
   subreddit: '/r/TatoebaLastDungeon/'
-streams: 
+streams:
   crunchyroll: ''
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl3X-zEFf3ZnYgu6MuUIO9q3'
   anione: ''
@@ -986,7 +987,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/heavens-design-team'
   official: 'https://tendebu.jp/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/heavens-design-team'
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl2EXwI9aJdqU567z6f3UUzU'
   anione: ''
@@ -1009,7 +1010,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/that-time-i-got-reincarnated-as-a-slime-season-2'
   official: 'https://www.ten-sura.com/anime/tensura'
   subreddit: '/r/TenseiSlime'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/that-time-i-got-reincarnated-as-a-slime'
   museasia: 'https://www.youtube.com/playlist?list=PLwLSw1_eDZl24o1N6adcgGPyIJPfJ21GL'
   anione: ''
@@ -1032,7 +1033,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/tropical-rouge-pretty-cure'
   official: 'http://www.toei-anim.co.jp/tv/tropical-rouge_precure/'
   subreddit: '/r/precure'
-streams: 
+streams:
   crunchyroll: 'http://crunchyroll.com/tropical-rouge-pretty-cure'
   museasia: ''
   anione: ''
@@ -1055,7 +1056,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/uma-musume-pretty-derby-season-2'
   official: 'https://anime-umamusume.jp/'
   subreddit: '/r/UmaMusume'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/umamusume-pretty-derby'
   museasia: ''
   anione: ''
@@ -1078,7 +1079,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/otherside-picnic'
   official: 'https://othersidepicnic.com/'
   subreddit: '/r/OthersidePicnic'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: 'https://www.youtube.com/playlist?list=PLxSscENEp7JhuqqXxuJ3FjDyQ0ISzzBZ7'
@@ -1100,7 +1101,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/wixoss'
   official: 'http://wixoss-diva.com/'
   subreddit: '/r/WIXOSSDiva'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/wixoss-divaalive'
   museasia: ''
   anione: ''
@@ -1122,7 +1123,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/wave-surfing-yappe'
   official: 'https://wave-anime.com/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/wave-lets-go-surfing-'
   museasia: ''
   anione: ''
@@ -1144,7 +1145,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/wonder-egg-priority'
   official: 'https://wonder-egg-priority.com/'
   subreddit: '/r/wondereggpriority'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -1166,7 +1167,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/world-trigger-new'
   official: 'http://www.toei-anim.co.jp/tv/wt/'
   subreddit: '/r/worldtrigger'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/world-trigger'
   museasia: ''
   anione: ''
@@ -1189,7 +1190,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/world-witches-hasshin-shimasu'
   official: 'http://w-witch.jp/ww_takeoff/'
   subreddit: '/r/StrikeWitches'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/strike-witches-501st-joint-fighter-wing-take-off'
   museasia: ''
   anione: ''
@@ -1212,7 +1213,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/the-promised-neverland-2nd-season'
   official: 'https://neverland-anime.com/'
   subreddit: '/r/thepromisedneverland'
-streams: 
+streams:
   crunchyroll: ''
   museasia: ''
   anione: ''
@@ -1235,7 +1236,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/yamishibai-japanese-ghost-stories-8th-season'
   official: 'https://www.tv-tokyo.co.jp/anime/yamishibai8/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/yamishibai'
   museasia: ''
   anione: ''
@@ -1258,7 +1259,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/yatogame-chan-kansatsu-nikki-3rd-season'
   official: 'https://yatogame.nagoya/'
   subreddit: ''
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/yatogame-chan-kansatsu-nikki'
   museasia: ''
   anione: ''
@@ -1281,7 +1282,7 @@ info:
   animeplanet: 'http://www.anime-planet.com/anime/laid-back-camp-2nd-season'
   official: 'https://yurucamp.jp/second/'
   subreddit: '/r/laidbackcamp'
-streams: 
+streams:
   crunchyroll: 'https://www.crunchyroll.com/laid-back-camp'
   museasia: ''
   anione: 'https://www.youtube.com/playlist?list=PLxSscENEp7JhsFhLkiHzyfMeO5unNiOEc'
@@ -1339,27 +1340,4 @@ streams:
   hulu|Hulu: ''
   youtube: 'https://www.youtube.com/playlist?list=PL58brFgdVYkoL_ADeArD9-jWyrIt8Rj9q'
   nyaa: 'D4DJ Petit Mix'
-#---
-#title: ''
-#alias: ['']
-#has_source: true
-#info:
-#  mal: ''
-#  anilist: ''
-#  anidb: ''
-#  kitsu: ''
-#  animeplanet: ''
-#  official: ''
-#  subreddit: ''
-#streams:
-#  crunchyroll: ''
-#  museasia: ''
-#  funimation|Funimation: ''
-#  wakanim|Wakanim: ''
-#  hidive: ''
-#  animelab|AnimeLab: ''
-#  crunchyroll_nsfw|Crunchyroll: ''
-#  vrv|VRV: ''
-#  hulu|Hulu: ''
-#  youtube: ''
-#  nyaa: ''
+---

--- a/season_configs/winter_2022.yaml
+++ b/season_configs/winter_2022.yaml
@@ -1,3 +1,4 @@
+---
 title: 'Akebi-chan no Sailor-fuku'
 alias: ["Akebi's Sailor Uniform"]
 has_source: true
@@ -1081,28 +1082,4 @@ streams:
   hulu|Hulu: ''
   youtube: ''
   nyaa: ''
-#---
-#title: ''
-#alias: ['']
-#has_source: true
-#info:
-#  mal: ''
-#  anilist: ''
-#  anidb: ''
-#  kitsu: ''
-#  animeplanet: ''
-#  official: ''
-#  subreddit: ''
-#streams:
-#  crunchyroll: ''
-#  museasia: ''
-#  funimation|Funimation: ''
-#  wakanim|Wakanim: ''
-#  hidive: ''
-#  animelab|AnimeLab: ''
-#  bilibili|Bilibili: ''
-#  crunchyroll_nsfw|Crunchyroll: ''
-#  vrv|VRV: ''
-#  hulu|Hulu: ''
-#  youtube: ''
-#  nyaa: ''
+---

--- a/season_configs/winter_2023.yaml
+++ b/season_configs/winter_2023.yaml
@@ -1,3 +1,4 @@
+---
 title: 'Flaglia: Natsuyasumi no Monogatari'
 title_en: ""
 has_source: true
@@ -1407,29 +1408,4 @@ streams:
     disney|Disney: ''
     youtube: ''
     nyaa: ''
-#---
-#title: ''
-#title_en: ''
-#alias: ['']
-#has_source: true
-#info:
-#  mal: ''
-#  anilist: ''
-#  anidb: ''
-#  kitsu: ''
-#  animeplanet: ''
-#  official: ''
-#  subreddit: ''
-#streams:
-#  crunchyroll: ''
-#  museasia: ''
-#  funimation|Funimation: ''
-#  wakanim|Wakanim: ''
-#  hidive: ''
-#  animelab|AnimeLab: ''
-#  bilibili|Bilibili: ''
-#  crunchyroll_nsfw|Crunchyroll: ''
-#  vrv|VRV: ''
-#  hulu|Hulu: ''
-#  youtube: ''
-#  nyaa: ''
+---


### PR DESCRIPTION
So because the config is all YAML files, I thought it might be wise to add a Github action that runs a YAML linting check on the seasonal configs to ensure they are all valid YAML files.

Tweeking the settings the linter uses can be found in `.github/config/.yamllint.yml`.

With the current settings, this Github action will run on every push and PR, on every branch. This can be tweeked in `.github/workflows/yaml_linter.yaml`.

Without knowing this repo's settings, it may (or may not) be possible for the checks to be bypassed. If you want to set it up where it needs to pass the check before it can be merged in - this is done in the repo's settings but let me know if you need a hand.

This PR also includes:
- Resolving the issues the linter identified with the current config files. This mostly involved:
  - Adding `---` to the top of files.
  - Removing trailing white spaces.
  - Adding a space between the `#` for comments, and the comment.
  - Some cases where the same entry was added in twice.
- Recreating `spring_2016.yaml`, because of an error with end of line characters that I wasn't able to resolve. So the old file was deleted and recreated.
  -  ⚠️ Git may think that this file has been edited and may fail on the linting again - but if that happens I know how to resolve it.
- The config templates that were at the bottom of files has been moved to it's own file - `season_configs/template.yaml` and the linter ignores this file.
