### PR TITLE
Add streaming service Hulu

### DIFF
--- a/examples/hulu-scrape_1-season.json
+++ b/examples/hulu-scrape_1-season.json
@@ -1,0 +1,3013 @@
+{
+	"props": {
+		"pageProps": {
+			"pageTitle": "Watch Tengoku Daimakyo Streaming Online | Hulu (Free Trial)",
+			"asPath": "/series/tengoku-daimakyo-c0bba144-1fa6-4ee5-affc-1029c77cfb71",
+			"pageType": "BrowsePage",
+			"query": {
+				"entity": "series",
+				"id": "tengoku-daimakyo-c0bba144-1fa6-4ee5-affc-1029c77cfb71"
+			},
+			"appsFlyerBannerKey": "",
+			"_sentryTraceData": "5c50a8e3d35d48639048fd690025501b-9f14d423b55d4332-0",
+			"_sentryBaggage": "sentry-environment=production,sentry-release=hitch%402.33.0,sentry-public_key=dfddf0aabbab4be4937d4082aad36bab,sentry-trace_id=5c50a8e3d35d48639048fd690025501b,sentry-sample_rate=0.05",
+			"latestSeason": {
+				"firstEpPremiereDate": null,
+				"lastEpPremiereDate": null,
+				"season": "1",
+				"seasonPremiereDates": [],
+				"previousSeason": "1",
+				"hasContentAvailable": false,
+				"hasUpcomingSeason": false,
+				"hasLastEpPremiered": true
+			},
+			"featureFlags": {
+				"has404CarouselEnabled": true,
+				"hasConnectedAuthEnabled": true,
+				"hasUnifiedLoginEnabled": true,
+				"hasUpdatedGenderOptions": true,
+				"hasOneTrustScriptEnabled": false,
+				"hasOneTrustFooterChangeActivated": false,
+				"hasSubscriberAgreementUpdateEnabled": true
+			},
+			"layout": {
+				"locale": "en-US",
+				"bigFooter": [
+		{
+			"sections": [
+				{
+					"section": "BROWSE",
+					"items": [
+			[
+				{
+					"link": "/content",
+					"title": "Streaming Library"
+				},
+				{
+					"link": "/live-tv",
+					"title": "Live TV"
+				},
+				{
+					"link": "/live-news",
+					"title": "Live News"
+				},
+				{
+					"link": "/live-sports",
+					"title": "Live Sports"
+				}
+			],
+			[
+				{
+					"link": "/hub/tv",
+					"title": "TV Shows"
+				},
+				{
+					"link": "/hub/movies",
+					"title": "Movies"
+				},
+				{
+					"link": "/hub/originals",
+					"title": "Originals"
+				},
+				{
+					"link": "/hub/networks",
+					"title": "Networks"
+				},
+				{
+					"link": "/hub/kids",
+					"title": "Kids"
+				},
+				{
+					"link": "/fx-on-hulu",
+					"title": "FX"
+				}
+			],
+			[
+				{
+					"link": "/max",
+					"title": "Max"
+				},
+				{
+					"link": "/cinemax",
+					"title": "Cinemax"
+				},
+				{
+					"link": "/showtime",
+					"title": "Showtime"
+				},
+				{
+					"link": "/starz",
+					"title": "STARZ"
+				}
+			],
+			[
+				{
+					"link": "/hulu-disney-espn-bundle-offer",
+					"title": "Disney Bundle Trio Basic"
+				},
+				{
+					"link": "/disney-bundle-hulu-no-ads",
+					"title": "Disney Bundle Trio Premium"
+				},
+				{
+					"link": "/disney-bundle-duo-basic",
+					"title": "Disney Bundle Duo Basic"
+				},
+				{
+					"link": "/student",
+					"title": "Student Discount"
+				}
+			]
+					]
+				},
+				{
+					"section": "HELP",
+					"items": [
+			[
+				{
+					"link": "//help.hulu.com/s/article/manage-subscription",
+					"title": "Account & Billing"
+				},
+				{
+					"link": "//help.hulu.com/s/article/how-much-does-hulu-cost",
+					"title": "Plans & Pricing"
+				},
+				{
+					"link": "//help.hulu.com/s/article/supported-devices",
+					"title": "Supported Devices"
+				},
+				{
+					"link": "//help.hulu.com/s/article/accessibility-features",
+					"title": "Accessibility"
+				}
+			]
+					]
+				},
+				{
+					"section": "ABOUT US",
+					"items": [
+			[
+				{
+					"link": "#hulushop",
+					"title": "Shop Hulu",
+					"modalId": "hulushop"
+				},
+				{
+					"link": "/press",
+					"title": "Press"
+				},
+				{
+					"link": "/jobs",
+					"title": "Jobs"
+				},
+				{
+					"link": "//help.hulu.com/s/article/how-to-contact-Hulu",
+					"title": "Contact"
+				}
+			]
+					]
+				}
+			],
+			"modals": [
+				{
+					"title": "Next stop: Shop Hulu, powered by Snowcommerce",
+					"id": "hulushop",
+					"css_class": "modal-dialog__default-display modal-dialog__size-small",
+					"closable": true,
+					"body": "<div class=\"HuluShopModal\">You are about to exit Hulu.com to visit the Shop Hulu site, where a different Terms of Use and Privacy Policy apply. Please note that the Shop Hulu site is owned and operated by Snowcommerce.<div class=\"modal-dialog__actions\"><a href=\"https://shop.hulu.com/?utm_source=hulu-com&utm_medium=referral&utm_campaign=hulu-footer\"><button class=\"button--cta button--black\">CONTINUE</button></a><button class=\"button--cta button--white\" onClick=\"document.getElementById('hulushop').getElementsByClassName('modal--close')[0].click()\">CANCEL</button></div></div>",
+					"footer": ""
+				}
+			]
+		}
+				],
+				"bundle": {
+		"amount": null
+				},
+				"components": [
+		{
+			"type": "navigation",
+			"style": null,
+			"sticky_mode": null,
+			"cta_always": true,
+			"enable_cta_toaster": null,
+			"enableMinimalNav": false,
+			"items": [],
+			"cta": "Start Your Free Trial",
+			"cta_button_style": "black",
+			"disable_logo": null,
+			"signup_flow_entry": "/signup/go/one-hulu",
+			"ctaDownloadAppText": null,
+			"welcomeOptions": "",
+			"enableStickyModeAlways": null,
+			"metrics": {}
+		},
+		{
+			"type": "detailentity_masthead",
+			"avFeatures": {
+				"items": [
+					"hd"
+				],
+				"truncatedItems": [
+					"hd"
+				]
+			},
+			"credits": null,
+			"disablePlayButton": false,
+			"disableMobilePlayButton": false,
+			"title": "Tengoku Daimakyo",
+			"entityId": "c0bba144-1fa6-4ee5-affc-1029c77cfb71",
+			"description": "In the year 2024, grotesque monsters lurk amongst the ruins of Japan, while remaining people scrape together what they can to survive. Kiruko accepts a mysterious woman's dying wish to take a boy named Maru to a place called Heaven.",
+			"entityType": "series",
+			"backgroundArtwork": {
+				"path": "https://img1.hulu.com/user/v3/artwork/c0bba144-1fa6-4ee5-affc-1029c77cfb71?base_image_bucket_name=image_manager&base_image=63b63c7b-c219-427b-933c-3d87875f297a",
+				"hue": 185
+			},
+			"brandArtwork": {
+				"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+			},
+			"verticalTileArtwork": {
+				"path": "https://img1.hulu.com/user/v3/artwork/c0bba144-1fa6-4ee5-affc-1029c77cfb71?base_image_bucket_name=image_manager&base_image=eb47ab4b-7489-4e1c-a3b0-18d1fe6cbe75",
+				"hue": 185
+			},
+			"titleArtwork": {
+				"path": "https://img1.hulu.com/user/v3/artwork/c0bba144-1fa6-4ee5-affc-1029c77cfb71?base_image_bucket_name=image_manager&base_image=8218d4e5-a816-44ed-91f6-7b1f44c7280e"
+			},
+			"headline": [
+				"Original",
+				"1 season available (11 episodes)"
+			],
+			"isHuluOriginal": true,
+			"tags": [
+				2023
+			],
+			"trailerText": "Watch Trailer",
+			"trailerName": "Tengoku Daimakyo Trailer",
+			"trailerEAB": "EAB::39a449cc-02f1-4520-a37f-10198ef6e437::61724508::231364813",
+			"trailerId": "39a449cc-02f1-4520-a37f-10198ef6e437",
+			"requirePremium": false,
+			"network": "Hulu Original Series",
+			"isHuluOriginalContent": true,
+			"isOriginalContent": true,
+			"premiereDate": "2023-04-01T05:00:00Z",
+			"rating": null,
+			"genres": [
+				{
+					"name": "International",
+					"hubPath": "/hub/international-tv"
+				},
+				{
+					"name": "Science Fiction",
+					"hubPath": "/hub/science-fiction-tv"
+				},
+				{
+					"name": "Thriller",
+					"hubPath": "/hub/thriller-tv"
+				},
+				{
+					"name": "Anime",
+					"hubPath": "/hub/anime-tv"
+				}
+			],
+			"disclaimer": "Stream thousands of shows and movies, with plans starting at $7.99/month.",
+			"ctaText": "Start Your Free Trial",
+			"ctaUrl": "/signup/go/one-hulu",
+			"legalText": "New subscribers only. Cancel anytime. Additional terms apply.",
+			"ctaDownloadAppText": "Watch Now With The Hulu App",
+			"infoLine": "1 season available (11 episodes)",
+			"disableInfo": false,
+			"contentType": "series",
+			"ribbon": {
+				"ribbonImage": "//cnbl-cdn.bamgrid.com/assets/1afce5041391d18ddcca64656450cce9664bc80d0618344d06ff6dcf005775e8/original",
+				"eyebrow": "DISNEY BUNDLE TRIO BASIC",
+				"buttonLink": "/signup/go/one-hulu?tab=bundles",
+				"buttonStyle": "white",
+				"buttonText": "GET ALL THREE",
+				"legalModalId": "",
+				"legalLink": "/terms/disneybundle/duotrio",
+				"legalText": "Terms apply",
+				"mainTextDt": "Get Hulu, Disney+, and ESPN+, all with ads, for $12.99/mo.",
+				"mainTextMobile": "Get Hulu, Disney+, and ESPN+, all with ads, for $12.99/mo.",
+				"learnMore": "",
+				"learnText": "",
+				"backgroundStyle": "blackTransparent"
+			},
+			"metrics": {}
+		},
+		{
+			"type": "collection_tabs",
+			"accentColor": "hsla(185, 100%, 60%, 1)",
+			"networkLogo": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439",
+			"includeHeroSlider": false,
+			"shouldCenterTabTitles": false,
+			"tabs": [
+				{
+					"title": "Episodes",
+					"model": {
+			"type": "episode_collection",
+			"collection": {
+				"id": "94",
+				"href": "https://discover.hulu.com/content/v5/hubs/series/c0bba144-1fa6-4ee5-affc-1029c77cfb71/collections/94?schema=0&personalized_layout_id=H4sIAAAAAAAAAMu1MjIwMjYwMzAxNDewqCkptjI0szC1sLQwsTAAAgDrT-cRHwAAAA",
+				"name": "Episodes",
+				"theme": "episode_collection",
+				"enabledTileLinks": false,
+				"enableSignupModal": null,
+				"collectionHubPath": null,
+				"seasons": [
+					{
+						"name": "Season 1",
+						"number": 1
+					}
+				],
+				"items": [
+					{
+						"id": "d29e078f-5b54-4f75-8796-b3ef8737b8a3",
+						"href": null,
+						"eabId": "EAB::d29e078f-5b54-4f75-8796-b3ef8737b8a3::61723939::231192565",
+						"type": "episode",
+						"name": "Heaven and Hell",
+						"description": "Japan has collapsed after the Great Disaster. Kiruko accepts a request to take a boy named Maru to a place called Heaven. Meanwhile, children live behind the walls of a nursery in luscious green surroundings.",
+						"rating": "TVMA",
+						"genres": [
+				"International",
+				"Science Fiction",
+				"Thriller",
+				"Anime"
+						],
+						"premiereDate": "2023-04-01T12:00:00Z",
+						"season": 1,
+						"number": 1,
+						"duration": 1434,
+						"seriesName": "Tengoku Daimakyo",
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img4.hulu.com/user/v3/artwork/d29e078f-5b54-4f75-8796-b3ef8737b8a3?base_image_bucket_name=image_manager&base_image=2d391fa4-982c-41df-8095-ed8e30ef28b4",
+					"hue": 215
+				},
+				"horizontalProgramTile": null,
+				"verticalHero": null,
+				"networkTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=fbce7a47-3972-434c-8b05-dc00d22eedb0"
+				},
+				"watermark": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+				},
+				"titleArtwork": null
+						}
+					},
+					{
+						"id": "c81aa598-d6ac-4eda-a899-dc109116cf5f",
+						"href": null,
+						"eabId": "EAB::c81aa598-d6ac-4eda-a899-dc109116cf5f::61723941::231192563",
+						"type": "episode",
+						"name": "Two Confessions",
+						"description": "At a strange inn, Maru and Kiruko sink into a drowsy slumber. They awaken to something monstrous under the faint light of the moon. At the nursery, Tokio becomes more suspicious of the world around him. Meanwhile, Shiro receives an unexpected message.",
+						"rating": "TVMA",
+						"genres": [
+				"International",
+				"Science Fiction",
+				"Thriller",
+				"Anime"
+						],
+						"premiereDate": "2023-04-01T12:00:00Z",
+						"season": 1,
+						"number": 2,
+						"duration": 1424,
+						"seriesName": "Tengoku Daimakyo",
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img1.hulu.com/user/v3/artwork/c81aa598-d6ac-4eda-a899-dc109116cf5f?base_image_bucket_name=image_manager&base_image=7624f188-d907-458d-91e3-2d45e9147e3e",
+					"hue": 205
+				},
+				"horizontalProgramTile": null,
+				"verticalHero": null,
+				"networkTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=fbce7a47-3972-434c-8b05-dc00d22eedb0"
+				},
+				"watermark": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+				},
+				"titleArtwork": null
+						}
+					},
+					{
+						"id": "645a8b33-f20b-4090-b52d-36297100c4b4",
+						"href": null,
+						"eabId": "EAB::645a8b33-f20b-4090-b52d-36297100c4b4::61723938::231344353",
+						"type": "episode",
+						"name": "Kiriko and Haruki",
+						"description": "Five years ago, in Asakusa, Robin, Haruki and his racer sister Kiriko had spent their days happily living in an orphanage.",
+						"rating": "TVMA",
+						"genres": [
+				"International",
+				"Science Fiction",
+				"Thriller",
+				"Anime"
+						],
+						"premiereDate": "2023-04-01T12:00:00Z",
+						"season": 1,
+						"number": 3,
+						"duration": 1424,
+						"seriesName": "Tengoku Daimakyo",
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img.hulu.com/user/v3/artwork/645a8b33-f20b-4090-b52d-36297100c4b4?base_image_bucket_name=image_manager&base_image=7cf20a9d-0d4f-447c-bdf8-15b4014d5b7d",
+					"hue": 25
+				},
+				"horizontalProgramTile": null,
+				"verticalHero": null,
+				"networkTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=fbce7a47-3972-434c-8b05-dc00d22eedb0"
+				},
+				"watermark": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+				},
+				"titleArtwork": null
+						}
+					},
+					{
+						"id": "478be705-8e2f-493f-be57-68ca33394aac",
+						"href": null,
+						"eabId": "EAB::478be705-8e2f-493f-be57-68ca33394aac::61724202::231651898",
+						"type": "episode",
+						"name": "Kuku",
+						"description": "Tokio is taken to see some bizarre-looking babies, and realizes just how little he understands about his surroundings. On a boat with no escape, Maru and Kiruko suffer a terrifying attack. As all is failing, t is up to Kiruko to devise a new strategy.",
+						"rating": "TVMA",
+						"genres": [
+				"International",
+				"Science Fiction",
+				"Thriller",
+				"Anime"
+						],
+						"premiereDate": "2023-04-01T12:00:00Z",
+						"season": 1,
+						"number": 4,
+						"duration": 1424,
+						"seriesName": "Tengoku Daimakyo",
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img4.hulu.com/user/v3/artwork/478be705-8e2f-493f-be57-68ca33394aac?base_image_bucket_name=image_manager&base_image=c8644f86-a94c-418b-acf7-988dc17db5ff",
+					"hue": 175
+				},
+				"horizontalProgramTile": null,
+				"verticalHero": null,
+				"networkTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=fbce7a47-3972-434c-8b05-dc00d22eedb0"
+				},
+				"watermark": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+				},
+				"titleArtwork": null
+						}
+					},
+					{
+						"id": "053f237d-c817-4567-9460-02e8252ac43b",
+						"href": null,
+						"eabId": "EAB::053f237d-c817-4567-9460-02e8252ac43b::61724203::232539697",
+						"type": "episode",
+						"name": "Day of Fate",
+						"description": "Maru and Kiruko return to Tokyo to find a neighborhood crowded with tents. When Maru goes off to a game center, Kiruko is left to gather information for herself, and hears a scary rumor.",
+						"rating": "TVMA",
+						"genres": [
+				"International",
+				"Science Fiction",
+				"Thriller",
+				"Anime"
+						],
+						"premiereDate": "2023-04-01T12:00:00Z",
+						"season": 1,
+						"number": 5,
+						"duration": 1424,
+						"seriesName": "Tengoku Daimakyo",
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img1.hulu.com/user/v3/artwork/053f237d-c817-4567-9460-02e8252ac43b?base_image_bucket_name=image_manager&base_image=a3c24e94-6ea3-4d36-85bd-790173634fd3",
+					"hue": 280
+				},
+				"horizontalProgramTile": null,
+				"verticalHero": null,
+				"networkTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=fbce7a47-3972-434c-8b05-dc00d22eedb0"
+				},
+				"watermark": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+				},
+				"titleArtwork": null
+						}
+					},
+					{
+						"id": "782f80ad-a3cf-46fc-a104-f8a0fbb9bde9",
+						"href": null,
+						"eabId": "EAB::782f80ad-a3cf-46fc-a104-f8a0fbb9bde9::61725250::235005473",
+						"type": "episode",
+						"name": "100％ Safe Water",
+						"description": "Maru and Kiruko are on the hunt for the Immortal Order. On the way, they stay at a hotel run by a girl named Totori. Dumping their bags and searching for safe drinking water, they stumble upon a badly injured man.",
+						"rating": "TVMA",
+						"genres": [
+				"International",
+				"Science Fiction",
+				"Thriller",
+				"Anime"
+						],
+						"premiereDate": "2023-05-06T12:00:00Z",
+						"season": 1,
+						"number": 6,
+						"duration": 1425,
+						"seriesName": "Tengoku Daimakyo",
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img.hulu.com/user/v3/artwork/782f80ad-a3cf-46fc-a104-f8a0fbb9bde9?base_image_bucket_name=image_manager&base_image=80666108-1476-4774-a027-c31ae153e207",
+					"hue": 50
+				},
+				"horizontalProgramTile": null,
+				"verticalHero": null,
+				"networkTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=fbce7a47-3972-434c-8b05-dc00d22eedb0"
+				},
+				"watermark": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+				},
+				"titleArtwork": null
+						}
+					},
+					{
+						"id": "38a17887-02e8-4f20-837e-e672cdfee183",
+						"href": null,
+						"eabId": "EAB::38a17887-02e8-4f20-837e-e672cdfee183::61725251::235236325",
+						"type": "episode",
+						"name": "The Immortal Order",
+						"description": "Maru and Kiruko find what they believe is the doctor and the Immortal Order. Instead, it is a hostile organization that is strongly opposed to the treatment that the Immortal Order provides.",
+						"rating": "TVMA",
+						"genres": [
+				"International",
+				"Science Fiction",
+				"Thriller",
+				"Anime"
+						],
+						"premiereDate": "2023-05-13T12:00:00Z",
+						"season": 1,
+						"number": 7,
+						"duration": 1424,
+						"seriesName": "Tengoku Daimakyo",
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img1.hulu.com/user/v3/artwork/38a17887-02e8-4f20-837e-e672cdfee183?base_image_bucket_name=image_manager&base_image=bf6bfc00-f421-45d8-b5e4-9edafe8b7ba9",
+					"hue": 35
+				},
+				"horizontalProgramTile": null,
+				"verticalHero": null,
+				"networkTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=fbce7a47-3972-434c-8b05-dc00d22eedb0"
+				},
+				"watermark": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+				},
+				"titleArtwork": null
+						}
+					},
+					{
+						"id": "7a0efea2-efe6-4f93-a2a4-6fb9fd80bb47",
+						"href": null,
+						"eabId": "EAB::7a0efea2-efe6-4f93-a2a4-6fb9fd80bb47::61725349::235820690",
+						"type": "episode",
+						"name": "Their Choices",
+						"description": "After killing the Man-Eaters, Maru and Kiruko finally meet Dr. Usami. He asks something difficult of them, and leads them both to a room where a horrifying scene awaits.",
+						"rating": "TVMA",
+						"genres": [
+				"International",
+				"Science Fiction",
+				"Thriller",
+				"Anime"
+						],
+						"premiereDate": "2023-05-20T12:00:00Z",
+						"season": 1,
+						"number": 8,
+						"duration": 1425,
+						"seriesName": "Tengoku Daimakyo",
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img2.hulu.com/user/v3/artwork/7a0efea2-efe6-4f93-a2a4-6fb9fd80bb47?base_image_bucket_name=image_manager&base_image=0f773610-aa9a-4ab1-b654-54e1c639d38c",
+					"hue": 355
+				},
+				"horizontalProgramTile": null,
+				"verticalHero": null,
+				"networkTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=fbce7a47-3972-434c-8b05-dc00d22eedb0"
+				},
+				"watermark": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+				},
+				"titleArtwork": null
+						}
+					},
+					{
+						"id": "ec9d74f8-2541-4201-aed2-d732e9f04bc2",
+						"href": null,
+						"eabId": "EAB::ec9d74f8-2541-4201-aed2-d732e9f04bc2::187252150::236806253",
+						"type": "episode",
+						"name": "Children of the Nursery",
+						"description": "Maru and Kiruko discover that Dr. Usami had a button with the same pattern as the logo they found on the Kiru-Beam. They decide to follow it's trail, and meet a mysterious informant along the way. Meanwhile, back at the nursery, an emergency meeting is held.",
+						"rating": "TVMA",
+						"genres": [
+				"International",
+				"Science Fiction",
+				"Thriller",
+				"Anime"
+						],
+						"premiereDate": "2023-05-27T12:00:00Z",
+						"season": 1,
+						"number": 9,
+						"duration": 1424,
+						"seriesName": "Tengoku Daimakyo",
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img.hulu.com/user/v3/artwork/ec9d74f8-2541-4201-aed2-d732e9f04bc2?base_image_bucket_name=image_manager&base_image=9bdf6706-de9a-4dd3-a3b5-c56c79fd89b6",
+					"hue": 190
+				},
+				"horizontalProgramTile": null,
+				"verticalHero": null,
+				"networkTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=fbce7a47-3972-434c-8b05-dc00d22eedb0"
+				},
+				"watermark": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+				},
+				"titleArtwork": null
+						}
+					},
+					{
+						"id": "ffba7648-c21e-4b5b-9dd2-d1b28aabf5bb",
+						"href": null,
+						"eabId": "EAB::ffba7648-c21e-4b5b-9dd2-d1b28aabf5bb::187616836::237893764",
+						"type": "episode",
+						"name": "The Walled Town",
+						"description": "Maru and Kiruko decide to head to the Ibaraki facility of the Takahara Academy. Since it's on the way, they agree to help Juichi confirm whether his baby is still alive. Arriving at the Walled Town, the situation is very different to what was expected.",
+						"rating": "TVMA",
+						"genres": [
+				"International",
+				"Science Fiction",
+				"Thriller",
+				"Anime"
+						],
+						"premiereDate": "2023-06-03T12:00:00Z",
+						"season": 1,
+						"number": 10,
+						"duration": 1424,
+						"seriesName": "Tengoku Daimakyo",
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img2.hulu.com/user/v3/artwork/ffba7648-c21e-4b5b-9dd2-d1b28aabf5bb?base_image_bucket_name=image_manager&base_image=fc8c8908-2204-40f6-824f-479855eb82da",
+					"hue": 50
+				},
+				"horizontalProgramTile": null,
+				"verticalHero": null,
+				"networkTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=fbce7a47-3972-434c-8b05-dc00d22eedb0"
+				},
+				"watermark": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+				},
+				"titleArtwork": null
+						}
+					},
+					{
+						"id": "c62aba03-e650-40f8-b383-f1011d51941f",
+						"href": null,
+						"eabId": "EAB::c62aba03-e650-40f8-b383-f1011d51941f::188093736::239009289",
+						"type": "episode",
+						"name": "The Test Begins",
+						"description": "Maru and Kiruko head to the Ibaraki facility after Juichi gives them his car. Meanwhile, a group of new 5th years join the academy. Mimihime notices that one child called Ohma seems very lonely, and tries to make friends. But Ohma has special reasons for keeping away from the other children.",
+						"rating": "TVMA",
+						"genres": [
+				"International",
+				"Science Fiction",
+				"Thriller",
+				"Anime"
+						],
+						"premiereDate": "2023-06-10T12:00:00Z",
+						"season": 1,
+						"number": 11,
+						"duration": 1424,
+						"seriesName": "Tengoku Daimakyo",
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img1.hulu.com/user/v3/artwork/c62aba03-e650-40f8-b383-f1011d51941f?base_image_bucket_name=image_manager&base_image=3cebf43c-4158-42cd-b343-57d2601fa5d0",
+					"hue": 110
+				},
+				"horizontalProgramTile": null,
+				"verticalHero": null,
+				"networkTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=fbce7a47-3972-434c-8b05-dc00d22eedb0"
+				},
+				"watermark": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+				},
+				"titleArtwork": null
+						}
+					}
+				]
+			},
+			"upsell": {
+				"seasons": 1,
+				"episodes": 11,
+				"name": "Tengoku Daimakyo"
+			}
+					}
+				},
+				{
+					"title": "Extras",
+					"model": {
+			"type": "grid_collection",
+			"title": "Extras",
+			"collection": {
+				"id": "241",
+				"href": "https://discover.hulu.com/content/v5/hubs/series/c0bba144-1fa6-4ee5-affc-1029c77cfb71/collections/241?schema=0&personalized_layout_id=H4sIAAAAAAAAAMu1MjIwMjYwMzAxNDewqCkptjI0szC1sLQwsTAAAgDrT-cRHwAAAA",
+				"name": "Extras",
+				"theme": "grid_collection",
+				"enabledTileLinks": false,
+				"enableSignupModal": null,
+				"collectionHubPath": null,
+				"seasons": null,
+				"items": [
+					{
+						"id": "39a449cc-02f1-4520-a37f-10198ef6e437",
+						"href": null,
+						"eabId": null,
+						"type": "extra",
+						"name": "Tengoku Daimakyo Trailer",
+						"description": "After the collapse of the world, Kiruko and Maru search for Heaven within the ruins of Japan.",
+						"rating": null,
+						"genres": [
+				"International",
+				"Science Fiction",
+				"Thriller",
+				"Anime"
+						],
+						"premiereDate": "2023-04-01T12:00:00Z",
+						"season": null,
+						"number": null,
+						"duration": 108,
+						"seriesName": null,
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img4.hulu.com/user/v3/artwork/39a449cc-02f1-4520-a37f-10198ef6e437?base_image_bucket_name=image_manager&base_image=a5fdb092-934c-4312-af0f-b845c05f23dd",
+					"hue": 355
+				},
+				"horizontalProgramTile": null,
+				"verticalHero": null,
+				"networkTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=fbce7a47-3972-434c-8b05-dc00d22eedb0"
+				},
+				"watermark": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+				},
+				"titleArtwork": null
+						}
+					}
+				]
+			},
+			"upsell": {
+				"seasons": 1,
+				"episodes": 11,
+				"name": "Tengoku Daimakyo"
+			}
+					}
+				},
+				{
+					"title": "Details",
+					"model": {
+			"type": "collection_details",
+			"collection": {
+				"theme": "details",
+				"name": "About this Show"
+			},
+			"entityType": "series",
+			"tags": [
+				2023
+			],
+			"name": "Tengoku Daimakyo",
+			"credits": null,
+			"avFeatures": {
+				"items": [
+					"hd"
+				],
+				"truncatedItems": [
+					"hd"
+				]
+			},
+			"description": "In the year 2024, grotesque monsters lurk amongst the ruins of Japan, while remaining people scrape together what they can to survive. Kiruko accepts a mysterious woman's dying wish to take a boy named Maru to a place called Heaven.",
+			"rating": null,
+			"genres": [
+				{
+					"name": "International",
+					"hubPath": "/hub/international-tv"
+				},
+				{
+					"name": "Science Fiction",
+					"hubPath": "/hub/science-fiction-tv"
+				},
+				{
+					"name": "Thriller",
+					"hubPath": "/hub/thriller-tv"
+				},
+				{
+					"name": "Anime",
+					"hubPath": "/hub/anime-tv"
+				}
+			]
+					}
+				}
+			],
+			"heroSliderCtaUrl": "",
+			"heroSliderCtaLegalText": "",
+			"heroSliderCtaDesc": "",
+			"heroSliderCtaText": "",
+			"heroSliderCtaPremiumDesc": "",
+			"network": "Tengoku Daimakyo",
+			"heroSliderCtaDisclaimer": "",
+			"metrics": {
+				"collectionIndex": 0
+			}
+		},
+		{
+			"type": "collection",
+			"collections": [
+				{
+					"model": {
+			"type": "simple_collection",
+			"title": "You May Also Like",
+			"collection": {
+				"id": "95",
+				"href": "https://discover.hulu.com/content/v5/hubs/series/c0bba144-1fa6-4ee5-affc-1029c77cfb71/collections/95?schema=0&personalized_layout_id=H4sIAAAAAAAAAMu1MjIwMjYwMzAxNDewqCkptjI0szC1sLQwsTAAAgDrT-cRHwAAAA",
+				"name": "You May Also Like",
+				"theme": "simple_collection",
+				"enabledTileLinks": true,
+				"enableSignupModal": null,
+				"collectionHubPath": null,
+				"seasons": null,
+				"items": [
+					{
+						"id": "d787e46a-dbb2-4f03-9d11-3680517ad451",
+						"href": "/series/tengoku-daimakyo-eng-d787e46a-dbb2-4f03-9d11-3680517ad451",
+						"eabId": null,
+						"type": "series",
+						"name": "Tengoku Daimakyo (Eng)",
+						"description": "In the year 2024, grotesque monsters lurk amongst the ruins of Japan, while remaining people scrape together what they can to survive. Kiruko accepts a mysterious woman's dying wish to take a boy named Maru to a place called Heaven.",
+						"rating": null,
+						"genres": [
+				"Science Fiction",
+				"Adventure",
+				"Animation",
+				"Anime",
+				"International",
+				"Horror",
+				"Thriller"
+						],
+						"premiereDate": "2023-04-01T12:00:00Z",
+						"season": null,
+						"number": null,
+						"duration": null,
+						"seriesName": null,
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img2.hulu.com/user/v3/artwork/d787e46a-dbb2-4f03-9d11-3680517ad451?base_image_bucket_name=image_manager&base_image=5b4b4a7e-1070-42bb-8a1b-ea3a1a2aaec5",
+					"hue": 185
+				},
+				"horizontalProgramTile": {
+					"path": "https://img2.hulu.com/user/v3/artwork/d787e46a-dbb2-4f03-9d11-3680517ad451?base_image_bucket_name=image_manager&base_image=087ad3c2-1777-4c8d-8895-07ed11a81498",
+					"hue": 15
+				},
+				"verticalHero": {
+					"path": "https://img2.hulu.com/user/v3/artwork/d787e46a-dbb2-4f03-9d11-3680517ad451?base_image_bucket_name=image_manager&base_image=b55b74b0-8a18-4f5f-aac9-1dee52c9e3b2",
+					"hue": 185
+				},
+				"networkTile": null,
+				"watermark": null,
+				"titleArtwork": null
+						}
+					},
+					{
+						"id": "45cfca29-3356-4871-a7a1-47c5c411435a",
+						"href": "/series/summer-time-rendering-eng-dub-45cfca29-3356-4871-a7a1-47c5c411435a",
+						"eabId": null,
+						"type": "series",
+						"name": "Summer Time Rendering (Eng Dub)",
+						"description": "Shinpei Ajiro, whose childhood friend Ushio Kofune died, returns to his hometown for the first time in two years. His best friend, Sou Hishigata, suspects something's off with Ushio's death, and someone else can die next.",
+						"rating": null,
+						"genres": [
+				"Drama",
+				"International"
+						],
+						"premiereDate": "2023-01-11T12:00:00Z",
+						"season": null,
+						"number": null,
+						"duration": null,
+						"seriesName": null,
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img2.hulu.com/user/v3/artwork/45cfca29-3356-4871-a7a1-47c5c411435a?base_image_bucket_name=image_manager&base_image=cd1c792c-16ac-4182-8112-7c6b5803ba14",
+					"hue": 255
+				},
+				"horizontalProgramTile": {
+					"path": "https://img2.hulu.com/user/v3/artwork/45cfca29-3356-4871-a7a1-47c5c411435a?base_image_bucket_name=image_manager&base_image=3a9aaffa-01bf-4542-8daa-d83da0712aa6",
+					"hue": 190
+				},
+				"verticalHero": {
+					"path": "https://img2.hulu.com/user/v3/artwork/45cfca29-3356-4871-a7a1-47c5c411435a?base_image_bucket_name=image_manager&base_image=9aff146c-2671-45d4-af12-24469db7e64b",
+					"hue": 255
+				},
+				"networkTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=fbce7a47-3972-434c-8b05-dc00d22eedb0"
+				},
+				"watermark": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+				},
+				"titleArtwork": {
+					"path": "https://img2.hulu.com/user/v3/artwork/45cfca29-3356-4871-a7a1-47c5c411435a?base_image_bucket_name=image_manager&base_image=590de654-33b5-4483-87a7-ee6a5f3bb3c3"
+				}
+						}
+					},
+					{
+						"id": "71657e15-fb0e-4b48-a1a6-23f0a23a9476",
+						"href": "/series/black-rock-shooter-dawn-fall-eng-71657e15-fb0e-4b48-a1a6-23f0a23a9476",
+						"eabId": null,
+						"type": "series",
+						"name": "Black Rock Shooter Dawn Fall (Eng)",
+						"description": "The year is 2062. Earth has been left in ruin after the failure of a labor automation project when the AI called Artemis waged war against humanity. A girl, Empress, awakens in a research lab. As one of the three surviving guardians, she must destroy the Orbital Elevator before Artemis can complete its construction. Failure will result in a machine army overrunning Earth. However, Artemis' Unmanned Forces and a cult may have motives of their own.",
+						"rating": null,
+						"genres": [
+				"Science Fiction",
+				"International",
+				"Animation",
+				"Anime"
+						],
+						"premiereDate": "2022-10-18T12:00:00Z",
+						"season": null,
+						"number": null,
+						"duration": null,
+						"seriesName": null,
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img.hulu.com/user/v3/artwork/71657e15-fb0e-4b48-a1a6-23f0a23a9476?base_image_bucket_name=image_manager&base_image=6b059a99-7658-4afb-a288-ebe1b906c8d6",
+					"hue": 215
+				},
+				"horizontalProgramTile": {
+					"path": "https://img.hulu.com/user/v3/artwork/71657e15-fb0e-4b48-a1a6-23f0a23a9476?base_image_bucket_name=image_manager&base_image=3cebd148-f82d-4a39-a9a0-ef5e3a02278f",
+					"hue": 225
+				},
+				"verticalHero": {
+					"path": "https://img.hulu.com/user/v3/artwork/71657e15-fb0e-4b48-a1a6-23f0a23a9476?base_image_bucket_name=image_manager&base_image=6ce63b7b-c362-4a76-9875-59813eb8ee38",
+					"hue": 215
+				},
+				"networkTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=fbce7a47-3972-434c-8b05-dc00d22eedb0"
+				},
+				"watermark": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+				},
+				"titleArtwork": {
+					"path": "https://img.hulu.com/user/v3/artwork/71657e15-fb0e-4b48-a1a6-23f0a23a9476?base_image_bucket_name=image_manager&base_image=8c8c7a38-ea09-4f8c-9876-03778ed3e3fe"
+				}
+						}
+					},
+					{
+						"id": "97f1d394-0ac7-48c2-bb1b-7b2575848441",
+						"href": "/series/the-rising-of-the-shield-hero-97f1d394-0ac7-48c2-bb1b-7b2575848441",
+						"eabId": null,
+						"type": "series",
+						"name": "The Rising of the Shield Hero",
+						"description": "A man equipped with only a shield is chosen to be one of the world's great defenders, but when a cruel betrayal shatters his reputation, he tries to regain the public's trust while fighting evil alongside a few devoted allies.",
+						"rating": null,
+						"genres": [
+				"Fantasy",
+				"Action",
+				"Adventure",
+				"Anime",
+				"Animation"
+						],
+						"premiereDate": "2019-01-09T12:00:00Z",
+						"season": null,
+						"number": null,
+						"duration": null,
+						"seriesName": null,
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img2.hulu.com/user/v3/artwork/97f1d394-0ac7-48c2-bb1b-7b2575848441?base_image_bucket_name=image_manager&base_image=bb19fa6c-9b3b-4d66-b467-a303c4b0e04c",
+					"hue": 35
+				},
+				"horizontalProgramTile": {
+					"path": "https://img2.hulu.com/user/v3/artwork/97f1d394-0ac7-48c2-bb1b-7b2575848441?base_image_bucket_name=image_manager&base_image=e45d0ac7-532a-4edf-ac5c-9dba4ae37b95",
+					"hue": 35
+				},
+				"verticalHero": {
+					"path": "https://img2.hulu.com/user/v3/artwork/97f1d394-0ac7-48c2-bb1b-7b2575848441?base_image_bucket_name=image_manager&base_image=67a0f2b5-bfeb-47d7-b65b-4c161a7ba92d",
+					"hue": 35
+				},
+				"networkTile": null,
+				"watermark": null,
+				"titleArtwork": null
+						}
+					},
+					{
+						"id": "0cad4e42-fd8d-42e1-a1ae-e9a3f64dcd65",
+						"href": "/series/tokyo-revengers-eng-0cad4e42-fd8d-42e1-a1ae-e9a3f64dcd65",
+						"eabId": null,
+						"type": "series",
+						"name": "Tokyo Revengers (Eng)",
+						"description": "Already low and down on his luck, Takemichi Hanagaki is devastated to learn that the love of his life from his middle school years has been killed by the criminal Tokyo Manji Gang. While Takemichi waits for a train the very next day, he is pushed from behind into the path of an oncoming train. Prepared to die, he instead wakes up to find he has traveled twelve years into the past and is again a middle school student. Now, Takemichi can rewrite history by making different choices in the hopes of preventing the death of his sweetheart.",
+						"rating": null,
+						"genres": [
+				"Animation",
+				"International",
+				"Anime"
+						],
+						"premiereDate": "2023-01-08T12:00:00Z",
+						"season": null,
+						"number": null,
+						"duration": null,
+						"seriesName": null,
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img4.hulu.com/user/v3/artwork/0cad4e42-fd8d-42e1-a1ae-e9a3f64dcd65?base_image_bucket_name=image_manager&base_image=408a46c5-5aa7-48db-a257-38fe06328786",
+					"hue": 355
+				},
+				"horizontalProgramTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/0cad4e42-fd8d-42e1-a1ae-e9a3f64dcd65?base_image_bucket_name=image_manager&base_image=df727844-277b-4988-8a10-deb407038b50",
+					"hue": 355
+				},
+				"verticalHero": {
+					"path": "https://img4.hulu.com/user/v3/artwork/0cad4e42-fd8d-42e1-a1ae-e9a3f64dcd65?base_image_bucket_name=image_manager&base_image=dc08eede-8663-458d-b096-48645876c694",
+					"hue": 355
+				},
+				"networkTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=fbce7a47-3972-434c-8b05-dc00d22eedb0"
+				},
+				"watermark": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+				},
+				"titleArtwork": {
+					"path": "https://img4.hulu.com/user/v3/artwork/0cad4e42-fd8d-42e1-a1ae-e9a3f64dcd65?base_image_bucket_name=image_manager&base_image=5469e60e-735b-48d3-8783-516b4194ca20"
+				}
+						}
+					},
+					{
+						"id": "79ace21f-5124-4913-950e-1afea45f723c",
+						"href": "/series/that-time-i-got-reincarnated-as-a-slime-79ace21f-5124-4913-950e-1afea45f723c",
+						"eabId": null,
+						"type": "series",
+						"name": "That Time I Got Reincarnated as a Slime",
+						"description": "After an assailant murders office worker Mikami Satoru, he finds himself reborn as a remarkably powerful slime in an alternate world, where he begins a quest to promote harmony among the world's different races.",
+						"rating": null,
+						"genres": [
+				"Fantasy",
+				"Anime",
+				"Adventure",
+				"Animation"
+						],
+						"premiereDate": "2018-10-02T12:00:00Z",
+						"season": null,
+						"number": null,
+						"duration": null,
+						"seriesName": null,
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img.hulu.com/user/v3/artwork/79ace21f-5124-4913-950e-1afea45f723c?base_image_bucket_name=image_manager&base_image=31a0196f-a06d-4f27-9621-0f1457f15df3",
+					"hue": 195
+				},
+				"horizontalProgramTile": {
+					"path": "https://img.hulu.com/user/v3/artwork/79ace21f-5124-4913-950e-1afea45f723c?base_image_bucket_name=image_manager&base_image=ca59c3aa-282f-4e43-9af8-5da1db4c5e98",
+					"hue": 195
+				},
+				"verticalHero": {
+					"path": "https://img.hulu.com/user/v3/artwork/79ace21f-5124-4913-950e-1afea45f723c?base_image_bucket_name=image_manager&base_image=96b040f0-1776-45e8-98b1-b16348d2d1d0",
+					"hue": 195
+				},
+				"networkTile": null,
+				"watermark": null,
+				"titleArtwork": {
+					"path": "https://img.hulu.com/user/v3/artwork/79ace21f-5124-4913-950e-1afea45f723c?base_image_bucket_name=image_manager&base_image=cb190145-79fc-4453-920a-01b2fd9b6dd3"
+				}
+						}
+					},
+					{
+						"id": "7b71b5a4-560b-4d8b-98c4-c5dee6004c21",
+						"href": "/series/chainsaw-man-7b71b5a4-560b-4d8b-98c4-c5dee6004c21",
+						"eabId": null,
+						"type": "series",
+						"name": "Chainsaw Man",
+						"description": "A teenage boy drowning in debt is forced to hunt down devils with his pet devil dog Pochita until he's betrayed and killed. In an unexpected turn of events, Pochita merges with his dead body and grants him the power of a Chainsaw Man!",
+						"rating": null,
+						"genres": [
+				"Action",
+				"Adventure",
+				"Animation",
+				"Anime"
+						],
+						"premiereDate": "2022-10-11T12:00:00Z",
+						"season": null,
+						"number": null,
+						"duration": null,
+						"seriesName": null,
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img3.hulu.com/user/v3/artwork/7b71b5a4-560b-4d8b-98c4-c5dee6004c21?base_image_bucket_name=image_manager&base_image=bd033d11-72ab-4100-a729-59eee4dc5523",
+					"hue": 205
+				},
+				"horizontalProgramTile": {
+					"path": "https://img3.hulu.com/user/v3/artwork/7b71b5a4-560b-4d8b-98c4-c5dee6004c21?base_image_bucket_name=image_manager&base_image=7002e231-e4a5-4878-8f48-ea4b5a95348c",
+					"hue": 205
+				},
+				"verticalHero": {
+					"path": "https://img3.hulu.com/user/v3/artwork/7b71b5a4-560b-4d8b-98c4-c5dee6004c21?base_image_bucket_name=image_manager&base_image=24133799-ae73-49ab-910a-4e483e68826f",
+					"hue": 205
+				},
+				"networkTile": null,
+				"watermark": null,
+				"titleArtwork": {
+					"path": "https://img3.hulu.com/user/v3/artwork/7b71b5a4-560b-4d8b-98c4-c5dee6004c21?base_image_bucket_name=image_manager&base_image=bacd5907-ef7d-4bd7-a280-27038cd44051"
+				}
+						}
+					},
+					{
+						"id": "02a3c8c0-4f1d-4610-bbb4-5b8e9468d7b1",
+						"href": "/series/bleach-thousand-year-blood-war-02a3c8c0-4f1d-4610-bbb4-5b8e9468d7b1",
+						"eabId": null,
+						"type": "series",
+						"name": "Bleach: Thousand-Year Blood War",
+						"description": "When a new enemy appears, Substitute Soul Reaper Ichigo Kurosaki jumps back into the battlefield with his Zanpakuto to help those in need.",
+						"rating": null,
+						"genres": [
+				"Animation",
+				"Anime"
+						],
+						"premiereDate": "2022-10-10T12:00:00Z",
+						"season": null,
+						"number": null,
+						"duration": null,
+						"seriesName": null,
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img3.hulu.com/user/v3/artwork/02a3c8c0-4f1d-4610-bbb4-5b8e9468d7b1?base_image_bucket_name=image_manager&base_image=de2a4ae9-9153-4f31-9bf0-84a611e8c3d0",
+					"hue": 0
+				},
+				"horizontalProgramTile": {
+					"path": "https://img3.hulu.com/user/v3/artwork/02a3c8c0-4f1d-4610-bbb4-5b8e9468d7b1?base_image_bucket_name=image_manager&base_image=fb63be54-4aec-4db1-bf27-abea35f293c9",
+					"hue": 0
+				},
+				"verticalHero": {
+					"path": "https://img3.hulu.com/user/v3/artwork/02a3c8c0-4f1d-4610-bbb4-5b8e9468d7b1?base_image_bucket_name=image_manager&base_image=1582a3ab-ab15-46fa-9ece-97bbb2b4a9d6",
+					"hue": 0
+				},
+				"networkTile": null,
+				"watermark": null,
+				"titleArtwork": {
+					"path": "https://img3.hulu.com/user/v3/artwork/02a3c8c0-4f1d-4610-bbb4-5b8e9468d7b1?base_image_bucket_name=image_manager&base_image=bcffa847-9be7-4041-9ddc-3152dce19d9f"
+				}
+						}
+					},
+					{
+						"id": "28ac7d35-3f2b-47db-8844-c27f7f3fa2a5",
+						"href": "/series/our-last-crusade-or-the-rise-of-a-new-world-28ac7d35-3f2b-47db-8844-c27f7f3fa2a5",
+						"eabId": null,
+						"type": "series",
+						"name": "Our Last Crusade or the Rise of a New World",
+						"description": "Sent to assassinate each other, Iska and Aliceliese’s initial encounter creates doubt in them both. But finding common ground would make them traitors to their countries. Circumstances made them enemies, but their conflicted hearts may make them lovers!",
+						"rating": null,
+						"genres": [
+				"Anime",
+				"Animation"
+						],
+						"premiereDate": "2020-10-07T12:00:00Z",
+						"season": null,
+						"number": null,
+						"duration": null,
+						"seriesName": null,
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img4.hulu.com/user/v3/artwork/28ac7d35-3f2b-47db-8844-c27f7f3fa2a5?base_image_bucket_name=image_manager&base_image=1bba2a42-d19b-45d2-93bd-7e3ed7874f0d",
+					"hue": 0
+				},
+				"horizontalProgramTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/28ac7d35-3f2b-47db-8844-c27f7f3fa2a5?base_image_bucket_name=image_manager&base_image=b8ef49f1-b680-4352-8c6a-45adb4db3279",
+					"hue": 0
+				},
+				"verticalHero": {
+					"path": "https://img4.hulu.com/user/v3/artwork/28ac7d35-3f2b-47db-8844-c27f7f3fa2a5?base_image_bucket_name=image_manager&base_image=c0e799c6-1edd-420a-b51f-2ab45570875f",
+					"hue": 225
+				},
+				"networkTile": null,
+				"watermark": null,
+				"titleArtwork": null
+						}
+					},
+					{
+						"id": "eb41ba38-51f7-4d22-b529-8691555a275a",
+						"href": "/movie/inu-oh-english-dub-eb41ba38-51f7-4d22-b529-8691555a275a",
+						"eabId": null,
+						"type": "movie",
+						"name": "Inu-Oh (English Dub)",
+						"description": "From visionary director Masaaki Yuasa, hailed by IndieWire as “one of the most creatively unbridled minds in all of modern animation,\" comes a revisionist rock opera about a 14th-century superstar whose dance moves take Japan by storm.",
+						"rating": "PG-13",
+						"genres": [
+				"Animation"
+						],
+						"premiereDate": "2022-08-12T12:00:00Z",
+						"season": null,
+						"number": null,
+						"duration": 5908,
+						"seriesName": null,
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img3.hulu.com/user/v3/artwork/eb41ba38-51f7-4d22-b529-8691555a275a?base_image_bucket_name=image_manager&base_image=c2ac6151-2b8f-4f58-908a-f29be8a85a0e",
+					"hue": 210
+				},
+				"horizontalProgramTile": {
+					"path": "https://img3.hulu.com/user/v3/artwork/eb41ba38-51f7-4d22-b529-8691555a275a?base_image_bucket_name=image_manager&base_image=10fd9de8-89ba-45c5-a234-1127a51089bb",
+					"hue": 210
+				},
+				"verticalHero": {
+					"path": "https://img3.hulu.com/user/v3/artwork/eb41ba38-51f7-4d22-b529-8691555a275a?base_image_bucket_name=image_manager&base_image=e10e35cc-635f-45a5-ae6b-f2c7affe1315",
+					"hue": 210
+				},
+				"networkTile": null,
+				"watermark": null,
+				"titleArtwork": {
+					"path": "https://img3.hulu.com/user/v3/artwork/eb41ba38-51f7-4d22-b529-8691555a275a?base_image_bucket_name=image_manager&base_image=5ce6aaff-81ad-4bfb-8309-bddf2cf5c03b"
+				}
+						}
+					},
+					{
+						"id": "a76ff77f-1588-4211-96e8-d2f9b8fbf400",
+						"href": "/series/id-invaded-a76ff77f-1588-4211-96e8-d2f9b8fbf400",
+						"eabId": null,
+						"type": "series",
+						"name": "ID: INVADED",
+						"description": "Meet Sakaido, a brilliant detective who solves cases by entering the world of the killer's unconscious mind: the id well. In the shadows of brutal and puzzling cases lurks John Walker, the Serial Killer Creator. Where will Sakaido's pursuit lead?",
+						"rating": null,
+						"genres": [
+				"Drama",
+				"Crime",
+				"Animation",
+				"Anime"
+						],
+						"premiereDate": "2019-12-15T12:00:00Z",
+						"season": null,
+						"number": null,
+						"duration": null,
+						"seriesName": null,
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img.hulu.com/user/v3/artwork/a76ff77f-1588-4211-96e8-d2f9b8fbf400?base_image_bucket_name=image_manager&base_image=09865d57-9326-417c-bab6-f2ac0a9b6b54",
+					"hue": 50
+				},
+				"horizontalProgramTile": {
+					"path": "https://img.hulu.com/user/v3/artwork/a76ff77f-1588-4211-96e8-d2f9b8fbf400?base_image_bucket_name=image_manager&base_image=7ed218a6-50be-4b7c-b57d-f2296fb30f9a",
+					"hue": 210
+				},
+				"verticalHero": {
+					"path": "https://img.hulu.com/user/v3/artwork/a76ff77f-1588-4211-96e8-d2f9b8fbf400?base_image_bucket_name=image_manager&base_image=a4548f51-ccac-4c71-b822-527858659262",
+					"hue": 210
+				},
+				"networkTile": null,
+				"watermark": null,
+				"titleArtwork": null
+						}
+					},
+					{
+						"id": "f3ebfa6a-c651-4e2b-b939-6c46dec8a66a",
+						"href": "/series/arifureta-from-commonplace-to-worlds-strongest-f3ebfa6a-c651-4e2b-b939-6c46dec8a66a",
+						"eabId": null,
+						"type": "series",
+						"name": "Arifureta: From Commonplace to World's Strongest",
+						"description": "After Hajime Nagumo and his high school class are suddenly summoned to a fantastical world, he tumbles into the depths of a monster-infested dungeon. To thrive in this savage world, Hajime will have no choice but to welcome the abyss.",
+						"rating": "TVMA",
+						"genres": [
+				"Animation",
+				"Anime"
+						],
+						"premiereDate": "2019-07-08T12:00:00Z",
+						"season": null,
+						"number": null,
+						"duration": null,
+						"seriesName": null,
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img1.hulu.com/user/v3/artwork/f3ebfa6a-c651-4e2b-b939-6c46dec8a66a?base_image_bucket_name=image_manager&base_image=61b99481-5728-47a7-8f57-2a00823770e8",
+					"hue": 5
+				},
+				"horizontalProgramTile": {
+					"path": "https://img1.hulu.com/user/v3/artwork/f3ebfa6a-c651-4e2b-b939-6c46dec8a66a?base_image_bucket_name=image_manager&base_image=10fc0842-3e40-47a7-b54e-231b657cfdf4",
+					"hue": 355
+				},
+				"verticalHero": {
+					"path": "https://img1.hulu.com/user/v3/artwork/f3ebfa6a-c651-4e2b-b939-6c46dec8a66a?base_image_bucket_name=image_manager&base_image=31cc4e6a-fc8b-44ac-805f-683f452da990",
+					"hue": 265
+				},
+				"networkTile": null,
+				"watermark": null,
+				"titleArtwork": null
+						}
+					},
+					{
+						"id": "326e55c4-924d-4f7d-b479-5bd250bfcabc",
+						"href": "/series/the-sacred-blacksmith-326e55c4-924d-4f7d-b479-5bd250bfcabc",
+						"eabId": null,
+						"type": "series",
+						"name": "The Sacred Blacksmith",
+						"description": "The bumbling knight Cecily is an unlikely heroine - until the blacksmith Luke comes to her aid, forging magic blades of supernatural strength. Cecily must wield this sacred steel against a cloaked fiend who is unleashing demons upon the land.",
+						"rating": "TVMA",
+						"genres": [
+				"Animation",
+				"Anime",
+				"International"
+						],
+						"premiereDate": "2009-10-03T12:00:00Z",
+						"season": null,
+						"number": null,
+						"duration": null,
+						"seriesName": null,
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img3.hulu.com/user/v3/artwork/326e55c4-924d-4f7d-b479-5bd250bfcabc?base_image_bucket_name=image_manager&base_image=dcabd7a0-de67-4083-864a-ea8481d73576",
+					"hue": 0
+				},
+				"horizontalProgramTile": {
+					"path": "https://img3.hulu.com/user/v3/artwork/326e55c4-924d-4f7d-b479-5bd250bfcabc?base_image_bucket_name=image_manager&base_image=112674cb-ae5c-4f2d-b23c-fc65248ead04",
+					"hue": 0
+				},
+				"verticalHero": {
+					"path": "https://img3.hulu.com/user/v3/artwork/326e55c4-924d-4f7d-b479-5bd250bfcabc?base_image_bucket_name=image_manager&base_image=18be40a6-c246-4554-8fbf-968463893415",
+					"hue": 0
+				},
+				"networkTile": null,
+				"watermark": null,
+				"titleArtwork": null
+						}
+					},
+					{
+						"id": "9d2ab176-0b3c-476f-a989-0578876b018d",
+						"href": "/series/black-rock-shooter-dawn-fall-9d2ab176-0b3c-476f-a989-0578876b018d",
+						"eabId": null,
+						"type": "series",
+						"name": "Black Rock Shooter Dawn Fall",
+						"description": "The year is 2062. Earth has been left in ruin after the failure of a labor automation project when the AI called Artemis waged war against humanity. A girl, Empress, awakens in a research lab. As one of the three surviving guardians, she must destroy the Orbital Elevator before Artemis can complete its construction. Failure will result in a machine army overrunning Earth. However, Artemis' Unmanned Forces and a cult may have motives of their own.",
+						"rating": null,
+						"genres": [
+				"Science Fiction",
+				"International",
+				"Animation",
+				"Anime"
+						],
+						"premiereDate": "2022-10-18T12:00:00Z",
+						"season": null,
+						"number": null,
+						"duration": null,
+						"seriesName": null,
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img3.hulu.com/user/v3/artwork/9d2ab176-0b3c-476f-a989-0578876b018d?base_image_bucket_name=image_manager&base_image=4b576aeb-67b4-4fe0-81c0-014928d98bd5",
+					"hue": 220
+				},
+				"horizontalProgramTile": {
+					"path": "https://img3.hulu.com/user/v3/artwork/9d2ab176-0b3c-476f-a989-0578876b018d?base_image_bucket_name=image_manager&base_image=7d13afa7-cbab-497a-99d9-b2b44cfe4074",
+					"hue": 225
+				},
+				"verticalHero": {
+					"path": "https://img3.hulu.com/user/v3/artwork/9d2ab176-0b3c-476f-a989-0578876b018d?base_image_bucket_name=image_manager&base_image=dcdd88bc-0060-4fad-9ced-a4e107f4e58e",
+					"hue": 215
+				},
+				"networkTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=fbce7a47-3972-434c-8b05-dc00d22eedb0"
+				},
+				"watermark": {
+					"path": "https://img4.hulu.com/user/v3/artwork/f812637b-6186-48e4-9b63-85167ba2cf17?base_image_bucket_name=image_manager&base_image=5d7f53a9-b8bf-4731-887a-0a87c4628439"
+				},
+				"titleArtwork": {
+					"path": "https://img3.hulu.com/user/v3/artwork/9d2ab176-0b3c-476f-a989-0578876b018d?base_image_bucket_name=image_manager&base_image=8fea53b2-a514-45ca-b2cd-c7adce67646e"
+				}
+						}
+					},
+					{
+						"id": "3fedb7c9-7fc1-4011-9344-33bc2ea01f2a",
+						"href": "/series/bem-3fedb7c9-7fc1-4011-9344-33bc2ea01f2a",
+						"eabId": null,
+						"type": "series",
+						"name": "BEM",
+						"description": "Humanoid monsters Bem, Bela, and Belo protect humanity and hope to one day become humans themselves. However, when a Mysterious Lady threatens their way of life, they're pulled into a plot unlike anything they've ever known.",
+						"rating": "TV14",
+						"genres": [
+				"Animation",
+				"Anime"
+						],
+						"premiereDate": "2019-07-14T12:00:00Z",
+						"season": null,
+						"number": null,
+						"duration": null,
+						"seriesName": null,
+						"artwork": {
+				"horizontalHero": {
+					"path": "https://img4.hulu.com/user/v3/artwork/3fedb7c9-7fc1-4011-9344-33bc2ea01f2a?base_image_bucket_name=image_manager&base_image=36cc73dd-6545-4c7f-b9db-0518a4460186",
+					"hue": 195
+				},
+				"horizontalProgramTile": {
+					"path": "https://img4.hulu.com/user/v3/artwork/3fedb7c9-7fc1-4011-9344-33bc2ea01f2a?base_image_bucket_name=image_manager&base_image=30b3a379-34dd-40d8-862c-6422087ec1fd",
+					"hue": 355
+				},
+				"verticalHero": {
+					"path": "https://img4.hulu.com/user/v3/artwork/3fedb7c9-7fc1-4011-9344-33bc2ea01f2a?base_image_bucket_name=image_manager&base_image=e18d3ae9-0a44-4f07-8f9b-6c48ebbc8c35",
+					"hue": 355
+				},
+				"networkTile": null,
+				"watermark": null,
+				"titleArtwork": null
+						}
+					}
+				]
+			},
+			"enabledTileLinks": true
+					}
+				}
+			],
+			"metrics": {
+				"collectionIndex": 3
+			}
+		},
+		{
+			"type": "player",
+			"metrics": {}
+		},
+		{
+			"type": "signup_modal",
+			"name": "Tengoku Daimakyo",
+			"availableSeasons": 1,
+			"episodeCount": 11,
+			"ctaText": "Start Your Free Trial",
+			"ctaUrl": "/signup/go/one-hulu",
+			"ctaDownloadAppText": "Watch Now",
+			"legalText": "For new subscribers only",
+			"bodyText": "No hidden fees, equipment rentals, or installation appointments.",
+			"contentType": "series",
+			"isOriginalContent": true,
+			"premiereDate": "2023-04-01T05:00:00Z",
+			"requirePremium": false,
+			"metrics": {}
+		},
+		{
+			"type": "tier_modal",
+			"id": "sportsaddon-modal",
+			"name": "Sports Add-on",
+			"price": "$9.99/month",
+			"body": "Stream every touchdown from every game, every Sunday during the NFL regular season with NFL RedZone, along with hundreds of hours of live sports –motorsports (MAVTV), horse racing (FanDuel TV/FanDuel Racing) to hunting and fishing (Outdoor Channel, Sportsman Channel).",
+			"shouldRandomize": false,
+			"logos": [
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/ec8159e7d204003c0e46f21072dacab58d86a496700beb4ed4f77b7b60e3e37b/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/2f78fe4d217c096d158f00eece7e8a9c67d567e9d238abd6297099e7fd633ed6/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/3bc25da921e02361cd29dd5b78151706837ddec42299b1eab4c0bec8a7b50e2c/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/b3ffc383fa43826d54610e1326c42c293242949f6b4f7982104565da69faa5df/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/d8721a1c2ba3675a48c6a8e983111d545786ab7ab8dfafc3c9f7ba37b0ffc49a/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/a6921dfd5061f532f63eb7ddc56aa39b358ad87231dae437dd67ccc25b7a38b4/original"
+				}
+			],
+			"metrics": {}
+		},
+		{
+			"type": "tier_modal",
+			"id": "espanol-modal",
+			"name": "Español Add-on",
+			"price": "$4.99/month",
+			"body": "Enjoy a collection of popular favorites in Spanish – CNN en Español, Discovery en Español, Discovery Familia, ESPN Deportes, History Channel en Español, and Universo.",
+			"shouldRandomize": false,
+			"logos": [
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/8a4ff3716ac76a0ede555b002589b578e78ee1ac75d215a7da02c0528186d234/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/f4ca338e72c6e02d6deab6830014ee5ed15c68575213041920fe25ce9a26ca36/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/be200cf2ea57d1a262eba57ce73e15065141a1e6c96fe6814d4e9b40a7b23065/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/eb493afba9617f1318eaf238366139a26a85dba1cac4eb62bcaba8f8dd61098a/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/de8fafa9f0e023116af53a93e817597ac15a66acdcc510763a27541236ae1405/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/63c356517b4099cc674965b859a267ecdf732f795f3ddbeab46512c01717ffa9/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/571968287ec7b1087b382cc96d4f7501965c6eb12cf5ac7969d6149fc9333935/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/e1ab4d05132815c111c7e6c1ce910453166d3cd7a6cb30cd8a8bd7f09602a27a/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/e28572c3b3c69d36d5f031137fa71c66fc754cff7dca94e68561744180395ad7/original"
+				}
+			],
+			"metrics": {}
+		},
+		{
+			"type": "tier_modal",
+			"id": "entertainment-modal",
+			"name": "Entertainment Add-on",
+			"price": "$7.99/month",
+			"body": "Stay current with additional news, entertainment, and lifestyle programming from American Heroes Channel, BET Her, Boomerang, CNBC World, Cooking Channel, Crime + Investigation, Destination America, Discovery Family, Discovery Life, Military History Channel, MTV2, MTV Classic, Nick Toons, Science, and Teen Nick.",
+			"shouldRandomize": false,
+			"logos": [
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/0ab82bfcacc470262d593761311df615afcf06a225fc76a1b7b3639c95cb05ec/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/ddb329360666ec283f41a6822bbaca2bf0f92fa3daa87babcfd4291391f09d31/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/607dcb9acf16bc2de181ab1e3e6457ad45d62d5aef771a341b5b7cb04e4f183e/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/464e555c84b580351a4b2e193459f07baed80854ae034cd1350a69a62a1bf286/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/aa6003125241eff00c7ddb6f0b6d37819c334f3b704d39110fa29ddd6e9ce796/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/9f060436044ac4ce14bacc4af832136c3c2517a9d666f6cb5162b0c0f512c639/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/e1a807a8f5cb7d6af4a342b8deb773d3aa795a958afbdd55b480b1ddd13120e0/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/e54039aae189599b75fa42b5dcf55d6d0e5e88d6ffff56dadd1c2edc920205b6/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/d7a43cc2d3d22735247ce06b828353ed62ec6262b7688f3d87df515039f7034f/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/343f2b0b596bb159366dd888adeba966c767cbcd75180d4a6a52d5cc1c42d342/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/1106f17568cac392e1f156ebdfd90d202a378619a3a682ae39e5b82e43251b55/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/4b08184bade28c32b290713a03989bd257dc4fed610cf0e9e7b3d8950b0deff8/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/702f02d9c9b5d79f79764011031fd74d27ce21755cf8290d2852534c54b2c1a4/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/f662a0239f3f4a4b7c1dc594f17dd0dd01a1af95e64ad28a4c5376f50ab265ba/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/e1e9230a34e2669d2f7ad66fad3b79f32153f169f671f0774db60140af0fe438/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/415f94db963a7e42a5959b26aee3d10202b300455cbcddbb791834e56b5e25d5/original"
+				},
+				{
+					"name": "",
+					"icon": "//cnbl-cdn.bamgrid.com/assets/ab64b682b66e652746b115a86bc3043e15453da2bdd94a446ebd6a35c3240b48/original"
+				}
+			],
+			"metrics": {}
+		},
+		{
+			"type": "modal",
+			"body": "18+ only. Any free trials valid for new and eligible returning subscribers only. For personal and non-commercial use only. Live TV is available in the 50 United States and the District of Columbia only. Compatible device and high-speed, broadband Internet connection required. Multiple concurrent streams and HD content may require higher bandwidth. Streaming content may count against your data usage. Location data required to access content. Live TV may vary by subscription and location. Click here to check channel availability in your area. Programming subject to regional availability, blackouts, and device restrictions. Number of permitted concurrent streams will vary based on the terms of your subscription. Pricing, channels, features, content, and compatible devices subject to change. Please review our Terms of Use (<a href=\"https://www.hulu.com/terms\" target=\"_blank\">https://www.hulu.com/terms</a>) and Privacy Policy (<a href=\"https://privacy.thewaltdisneycompany.com/en/current-privacy-policy/\" target=\"_blank\">https://privacy.thewaltdisneycompany.com/en/current-privacy-policy/</a>).\n<br>\n<br>\nU.S. residents. Includes certain combinations of Disney+, Hulu, and ESPN+, subject to change. Offer valid for eligible subscribers, devices, and billing partners. Access content from each service separately. Location data may be required to watch certain content. For detailed information on billing and cancelation, please visit the Hulu Help Center (<a href=\"https://help.hulu.com/s/article/hulu-disney-espn-bundle\" target=\"_blank\">https://help.hulu.com/s/article/hulu-disney-espn-bundle</a>).",
+			"modalTitle": "",
+			"id": "live-tv-legal-modal",
+			"metrics": {}
+		},
+		{
+			"type": "modal",
+			"body": "Due to streaming rights, a few shows with an ad break before and after. <a href=\"https://help.hulu.com/en-us/included-in-no-commercials-plan\" target=\"_blank\">Which shows?</a>",
+			"modalTitle": "",
+			"id": "exception-shows-modal",
+			"metrics": {}
+		},
+		{
+			"type": "html_module",
+			"html_code": "<style>\n    .value-prop-disclaimer {\n        color: #586174;\n        font-size: 10px;\n        font-weight: normal;\n        line-height: 16px;\n    }\n    .Masthead__legal.section-disclaimer .button-link {\n        color: white;\n    }\n</style>",
+			"metrics": {}
+		},
+		{
+			"type": "exp_plan_comparison_chart_with_toggle",
+			"headline": "Select Your Plan",
+			"description": "No hidden fees, equipment rentals, or installation appointments.<br /><b>Switch plans or cancel anytime.**</b>",
+			"addonsHeadline": "Available Add-ons",
+			"addonsDescription": "Add-ons available at an additional cost.<br />Add them up after you sign up for Hulu.",
+			"isDark": false,
+			"bundle": {
+				"headline": "Bundle ",
+				"description": "Includes Hulu (plan of your choice), Disney+, and ESPN+.",
+				"leftHeadline": "BASE PLANS",
+				"rightHeadline": "BUNDLE / SAVE",
+				"modal": {}
+			},
+			"bundlePlans": [
+				{
+					"slug": "trio-basic",
+					"headline": "Disney Bundle Trio Basic",
+					"eyebrow": "",
+					"disclaimer": {
+			"id": null,
+			"richText": "",
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"ctaText": "$12.99 / MONTH",
+					"mobileCtaText": "$12.99 / mo.",
+					"ctaAction": "/signup",
+					"badge": "",
+					"ctaBtnStyle": "none",
+					"program": "hulu-disney-espn-bundle-offer"
+				},
+				{
+					"slug": "trio-premium",
+					"headline": "Disney Bundle Trio Premium",
+					"eyebrow": "",
+					"disclaimer": {
+			"id": null,
+			"richText": "",
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"ctaText": "$19.99 / MONTH",
+					"mobileCtaText": "$19.99 / mo.",
+					"ctaAction": "/signup",
+					"badge": "",
+					"ctaBtnStyle": "none",
+					"program": "disney-bundle-hulu-no-ads"
+				},
+				{
+					"slug": "live-tv",
+					"headline": "Hulu + Live TV",
+					"eyebrow": "",
+					"disclaimer": {
+			"id": null,
+			"richText": "",
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"ctaText": "$69.99 / MONTH",
+					"mobileCtaText": "$69.99 / mo.",
+					"ctaAction": "/signup/go/live",
+					"badge": "",
+					"ctaBtnStyle": "black",
+					"program": ""
+				}
+			],
+			"plans": [
+				{
+					"slug": "hulu",
+					"headline": "Hulu (With Ads)",
+					"eyebrow": "30 DAY FREE TRIAL",
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"ctaText": "$7.99 / MONTH",
+					"mobileCtaText": "$7.99/mo.",
+					"ctaAction": "/signup/go/sash",
+					"badge": "MOST POPULAR",
+					"ctaBtnStyle": "black",
+					"program": ""
+				},
+				{
+					"slug": "no-ad",
+					"headline": "Hulu (No Ads)",
+					"eyebrow": "30 DAY FREE TRIAL",
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"ctaText": "$14.99 / month",
+					"mobileCtaText": "$14.99 / mo.",
+					"ctaAction": "/signup/go/noah",
+					"ctaBtnStyle": "black",
+					"program": ""
+				}
+			],
+			"pricingRows": [
+				{
+					"slug": "monthly-pricing-row",
+					"headline": "Monthly price",
+					"bundleHeadline": "Monthly price. Save up to $15.98/mo.*",
+					"prices": [
+			{
+				"text": "$7.99/mo.",
+				"bundle": {
+					"originalPriceText": "$25.97/mo.",
+					"discountedPriceText": "$12.99/mo.*"
+				}
+			},
+			{
+				"text": "$14.99/mo.",
+				"bundle": {
+					"originalPriceText": "$35.97/mo.",
+					"discountedPriceText": "$19.99/mo.*"
+				}
+			},
+			{
+				"bundle": {
+					"originalPriceText": "",
+					"discountedPriceText": "$69.99/mo."
+				}
+			}
+					]
+				}
+			],
+			"bundleFeatures": [
+				{
+					"slug": "subscriptions-included",
+					"headline": "Subscriptions included in each plan",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": "",
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": ""
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": false,
+				"text": "Disney+ (With Ads), Hulu (With Ads), ESPN+ (With Ads)"
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": false,
+				"text": "Disney+ (No Ads), Hulu (No Ads), ESPN+ (With Ads)"
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": false,
+				"text": "Hulu (With Ads) + Live TV, Disney+ (With Ads), ESPN+ (With Ads)"
+			}
+					]
+				},
+				{
+					"slug": "bundle-streaming-library",
+					"headline": "Hulu Streaming library with tons of episodes and movies",
+					"description": {
+			"richText": "Watch full seasons of exclusively streaming series, classic favorites, Hulu Originals, hit movies, current episodes, kids shows, and tons more. <br/><br/>Watch on 2 different screens at the same time.",
+			"modalId": "bundle-streaming-library-modal"
+					},
+					"disclaimer": {
+			"id": "",
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": ""
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": true
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": true
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "bundle-episodes-air",
+					"headline": "Most new episodes the day after they air†",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": "episodes-air-disclaimer",
+			"richText": "†For current-season shows in the streaming library only",
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": true
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": true
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "bundle-hulu-originals",
+					"headline": "Access to award-winning Hulu Originals",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": true
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": true
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "bundle-devices",
+					"headline": "Watch on your favorite devices, including TV, laptop, phone, or tablet",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": true
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": true
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "bundle-download-hulu",
+					"headline": "Download and watch on Hulu",
+					"description": {
+			"richText": "Download titles to your supported device for on-the-go-streaming. Save your data and watch offline. <br/><br/><div style=\"font-size: 12px; line-height: 14px;\"><i>Select content available for download.</i></div>",
+			"modalId": "bundle-download-modal"
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": "",
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": false
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": true
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": false
+			}
+					]
+				},
+				{
+					"slug": "bundle-bundle-live-tv",
+					"headline": "Live TV with 85+ top channels. No cable required.",
+					"description": {
+			"richText": "- Live sports including the NCAA, NBA, NHL, NFL, the English Premier League, and more.<br/><br/>- Breaking news on CNN, Fox News, and MSNBC, with local news channels in many cities.<br/><br/>- Live entertainment on ABC, CBS, FOX, NBC and more, including local channels and events like the Oscars®.",
+			"modalId": "bundle-live-tv-modal"
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": "",
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": false
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": false
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "bundle-live-tv-guide",
+					"headline": "Live TV guide to navigate channels",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": "",
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": false
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": false
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "bundle-cloud-dvr",
+					"headline": "Record Live TV with Unlimited DVR",
+					"description": {
+			"richText": "Store live TV recordings for up to nine months and fast-forward through your DVR content.<br/><br/><div style=\"font-size: 12px; line-height: 14px;\"><i>Unlimited DVR recording is not available for on-demand shows.</i></div>",
+			"modalId": "bundle-cloud-dvr-modal"
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": "",
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": false
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": false
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": true
+			}
+					]
+				}
+			],
+			"features": [
+				{
+					"slug": "streaming-library",
+					"headline": "Streaming Library with tons of TV episodes and movies",
+					"description": {
+			"richText": "Watch full seasons of exclusively streaming series, classic favorites, Hulu Originals, hit movies, current episodes, kids shows, and tons more.",
+			"modalId": "streaming-library-description"
+					},
+					"disclaimer": {
+			"id": "",
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": ""
+					},
+					"plans": [
+			{
+				"slug": "hulu",
+				"isApplicable": true
+			},
+			{
+				"slug": "no-ad",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "episodes-air",
+					"headline": "Most new episodes the day after they air†",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": "episodes-air-disclaimer",
+			"richText": "†For current-season shows in the streaming library only",
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "hulu",
+				"isApplicable": true
+			},
+			{
+				"slug": "no-ad",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "hulu-originals",
+					"headline": "Access to award-winning Hulu Originals",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "hulu",
+				"isApplicable": true
+			},
+			{
+				"slug": "no-ad",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "devices",
+					"headline": "Watch on your favorite devices, including TV, laptop, phone, or tablet",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "hulu",
+				"isApplicable": true
+			},
+			{
+				"slug": "no-ad",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "user-profiles",
+					"headline": "Up to 6 user profiles",
+					"description": {
+			"richText": "Now up to six members of your household can have separate profiles so that favorites and recommendations are unique to each viewer.",
+			"modalId": "user-profiles-modal"
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "hulu",
+				"isApplicable": true
+			},
+			{
+				"slug": "no-ad",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "different-screens",
+					"headline": "Watch on 2 different screens at the same time",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "hulu",
+				"isApplicable": true
+			},
+			{
+				"slug": "no-ad",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "no-ads",
+					"headline": "No ads in streaming library",
+					"description": {
+			"richText": "Stream our library of shows and movies without ad interruptions. <br/><br/><div style=\"font-size: 12px; line-height: 14px;\"><i>Due to streaming rights, a few shows are not included in the Hulu (No Ads) plan and will instead play interruption-free with a short ad break before and after each episode. Visit the Hulu Help Center for a list of shows.<br/>Hulu + Live TV plan: Switch to this plan after sign-up to get ad-free experience of Hulu’s streaming library only; live and VOD content available through Live TV plan plays with ads. No free trial available.</i></div>",
+			"modalId": "no-ads-modal"
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": "",
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "hulu",
+				"isApplicable": false
+			},
+			{
+				"slug": "no-ad",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "download-and-watch",
+					"headline": "Download and watch",
+					"description": {
+			"richText": "Download titles to your supported device for on-the-go-streaming. Save your data and watch offline.<br/><br/><div style=\"font-size: 12px; line-height: 14px;\"><i>Select content available for download.</i></div>",
+			"modalId": "download-and-watch-modal"
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": "",
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "hulu",
+				"isApplicable": false
+			},
+			{
+				"slug": "no-ad",
+				"isApplicable": true
+			}
+					]
+				}
+			],
+			"bundleFeatureDisclaimers": [
+				{
+					"richText": "*Savings compared to regular monthly price of each service. ",
+					"modalLinkText": "Terms apply.",
+					"modalContent": "U.S. residents, 18+ only. Access content from each service separately. Location data required to watch certain content. Offer valid for eligible subscribers only. Subject to <a href=\"https://www.hulu.com/terms\">Hulu Subscriber Agreement</a>. <br><br> For detailed information on billing and cancelation, please visit the Hulu Help Center (<a href=\"https://help.hulu.com/s/article/hulu-disney-espn-bundle\">https://help.hulu.com/s/article/hulu-disney-espn-bundle</a>). © 2022 Disney and its related entities."
+				},
+				{
+					"richText": "**Switches from Live TV to Hulu take effect as of the next billing cycle",
+					"modalLinkText": "",
+					"modalContent": null
+				},
+				{
+					"richText": "†For current-season shows in the streaming library only",
+					"modalLinkText": "",
+					"modalContent": null
+				},
+				{
+					"richText": "",
+					"modalLinkText": "",
+					"modalContent": null
+				},
+				{
+					"richText": "",
+					"modalLinkText": "",
+					"modalContent": null
+				}
+			],
+			"featureDisclaimers": [
+				{
+					"richText": "†For current-season shows in the streaming library only",
+					"modalLinkText": "",
+					"modalContent": null
+				},
+				{
+					"richText": "**Switches from Live TV to Hulu take effect as of the next billing cycle",
+					"modalLinkText": "",
+					"modalContent": null
+				}
+			],
+			"bundleAddons": [
+				{
+					"slug": "max",
+					"headline": "Max",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": true
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": true
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "cinemax",
+					"headline": "CINEMAX®",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": true
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": true
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "showtime",
+					"headline": "SHOWTIME®",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": true
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": true
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "starz",
+					"headline": "STARZ®",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": true
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": true
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "unlimited-screen",
+					"headline": "Unlimited Screens",
+					"description": {
+			"richText": "For everyone in the home.<br/><br/>• Upgrade to watch on unlimited screens at home<br/>• Plus, enjoy 3 screens when you’re on the go<br/><br/><div style=\"font-size: 12px; line-height: 14px;\"><i>Premium network restrictions apply.</i></div>",
+			"modalId": "unlimited-screen-modal"
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": false
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": false
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "entertainment-add-on",
+					"headline": "Entertainment Add-on",
+					"description": {
+			"richText": "Stay current with additional news, entertainment, and lifestyle programming from American Heroes Channel, BET Her, CNBC World, Cooking Channel, Crime + Investigation, Destination America, Discovery Family, Discovery Life, Magnolia Network, Military History Channel, MTV2, MTV Classic, Nick Toons, Science, and Teen Nick.",
+			"modalId": "entertainment-modal"
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": false
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": false
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "espanol-add-on",
+					"headline": "Español Add-on",
+					"description": {
+			"richText": "Enjoy a collection of popular favorites in Spanish – CNN en Español, Discovery en Español, Discovery Familia, ESPN Deportes, History Channel en Español, and Universo.",
+			"modalId": "espanol-modal"
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": false
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": false
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "sports-add-on",
+					"headline": "Sports Add-on",
+					"description": {
+			"richText": "Stream every touchdown from every game, every Sunday during the NFL regular season with NFL RedZone, along with hundreds of hours of live sports –motorsports (MAVTV), horse racing (FanDuel TV/FanDuel Racing) to hunting and fishing (Outdoor Channel, Sportsman Channel).",
+			"modalId": "sportsaddon-modal"
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "trio-basic",
+				"isApplicable": false
+			},
+			{
+				"slug": "trio-premium",
+				"isApplicable": false
+			},
+			{
+				"slug": "live-tv",
+				"isApplicable": true
+			}
+					]
+				}
+			],
+			"addons": [
+				{
+					"slug": "max",
+					"headline": "Max",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "hulu",
+				"isApplicable": true
+			},
+			{
+				"slug": "no-ad",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "cinemax",
+					"headline": "CINEMAX®",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "hulu",
+				"isApplicable": true
+			},
+			{
+				"slug": "no-ad",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "showtime",
+					"headline": "SHOWTIME®",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "hulu",
+				"isApplicable": true
+			},
+			{
+				"slug": "no-ad",
+				"isApplicable": true
+			}
+					]
+				},
+				{
+					"slug": "starz",
+					"headline": "STARZ®",
+					"description": {
+			"richText": null,
+			"modalId": ""
+					},
+					"disclaimer": {
+			"id": null,
+			"richText": null,
+			"modalLinkText": "",
+			"modalContent": null
+					},
+					"plans": [
+			{
+				"slug": "hulu",
+				"isApplicable": true
+			},
+			{
+				"slug": "no-ad",
+				"isApplicable": true
+			}
+					]
+				}
+			],
+			"bundleAddonDisclaimers": [],
+			"addonDisclaimers": [],
+			"metrics": {}
+		},
+		{
+			"type": "html_module",
+			"html_code": "<style>\n    .is-dark .plans-container__features-container__disclaimer > a {\n        color: white;\n        text-decoration: underline;\n    }\n    .plans-container__features-container__disclaimer > a {\n        color: #272c34;\n        text-decoration: underline;\n    }\n  .exp-plans-container .plan-head__card-title {\n    padding-left: 0px;\n    padding-right: 0px;\n  }\n  .exp-plans-container .plan-head__card.plan-head__card-2.col-xs-4.plan-head__card--short .plan-head__card-content .plan-head__card-title {\n    padding-top: 18px;\n  }\n  .exp-plans-container .plan-head__card-eyebrow-image > img {\n    max-height: 20px;\n  }\n  .exp-plans-container .plan-feature__bullet_text {\n      font-size: 14px;\n  }\n  @media (min-width: 540px) {\n    .exp-plans-container .plan-head__card-title {\n      padding-left: 20px;\n      padding-right: 20px;\n    }\n    .exp-plans-container .plan-head__card.plan-head__card-2.col-xs-4.plan-head__card--short .plan-head__card-content .plan-head__card-title {\n      padding-top: 18px;\n    }\n    .exp-plans-container .plan-head__card-eyebrow-image > img {\n      max-height: 30px;\n    }\n  }\n\n  @media (min-width: 768px) {\n    .exp-plans-container .plan-head__card-title {\n      padding-left: 0px;\n      padding-right: 0px;\n    }\n    .exp-plans-container .plan-head__card.plan-head__card-2.col-xs-4.plan-head__card--short .plan-head__card-content .plan-head__card-title {\n      padding-top: 0px;\n    }\n    .exp-plans-container .plan-head__card-eyebrow-image > img {\n      max-height: 30px;\n    }\n  }\n  @media (min-width: 1024px) {\n    .exp-plans-container .plan-head-column-for-new-toggle.plan-head-column--short {\n        margin-top: -27px;\n    }\n    .exp-plans-container .plan-head-column-for-new-toggle.plan-head-column--short .bundle-header-with-new-toggle {\n        margin-top: 27px;\n    }\n    /* .is-dark .col-xs-4.plan-feature__check-0, .is-dark .plan-head__card-0.plan-head__card--short {\n        background-color: transparent;\n    } */\n\n    /* .exp-plans-container .plan-head__card.plan-head__card-0.col-xs-4.plan-head__card--short, .plan-head__card.plan-head__card-1.col-xs-4.plan-head__card--short,\n        .plan-head__card.plan-head__card-2.col-xs-4.plan-head__card--short {\n            margin-top: 27px;\n    } */\n\n    .exp-plans-container .plan-head__card-title {\n      padding-left: 15px;\n      padding-right: 15px;\n    }\n    .exp-plans-container .plan-head__card.plan-head__card-2.col-xs-4.plan-head__card--short .plan-head__card-content .plan-head__card-title {\n      padding-top: 24px;\n    }\n    .exp-plans-container .plan-head__card-eyebrow-image > img {\n      max-height: 30px;\n    }\n    .exp-plans-container .plan-head__card-title > span {\n      font-size: 18px;\n    }\n  }\n  @media (min-width: 1600px) {\n    .exp-plans-container .plan-head__card-title {\n      padding-left: 30px;\n      padding-right: 30px;\n    }\n    .exp-plans-container .plan-head__card.plan-head__card-2.col-xs-4.plan-head__card--short .plan-head__card-content .plan-head__card-title {\n      padding-top: 24px;\n    }\n    .exp-plans-container .plan-head__card-eyebrow-image > img {\n      max-height: 30px;\n    }\n    .exp-plans-container .plan-head__card-title > span {\n      font-size: 18px;\n    }\n  }\n</style>",
+			"metrics": {}
+		},
+		{
+			"type": "html_module",
+			"html_code": "<script type=\"text/javascript\">\n    const SWITCH_ID = 'toggle-switch';\n    const IMAGE_CLASS_NAME = 'plan-head__card-eyebrow-image';\n    const DARK_IMAGE = '/static/hitch/static/logos/bundles-dark.svg';\n    const WHITE_IMAGE = '/static/hitch/static/logos/bundles.svg';\n    const RENDER_TIME = 10;\n\n    const switchElement = document.getElementById(SWITCH_ID).parentNode.parentNode;\n\n    switchElement.addEventListener('load', () => {\n    setTimeout(() => {\n        changeImage();\n    }, RENDER_TIME);\n    });\n\n    switchElement.addEventListener('click', () => {\n    setTimeout(() => {\n        changeImage();\n    }, RENDER_TIME);\n    });\n\n    const changeImage = () => {\n    const imageContainers = document.getElementsByClassName(IMAGE_CLASS_NAME);\n    const compChartElement = document.getElementById('plans');\n    const isDark = compChartElement.classList.contains('is-dark');\n\n    Array.from(imageContainers).forEach((container) => {\n        container.children[0].src = isDark ? DARK_IMAGE : WHITE_IMAGE;\n    });\n    };\n</script>\n",
+			"metrics": {}
+		},
+		{
+			"type": "modal",
+			"body": "<strong>What's Included in The Disney Bundle?</strong>\n<br>\n<br>\n<img src=\"/static/hitch/static/icons/Pricing_Checkmark_black.svg\" role=\"presentation\"> Subscriptions to Disney+, ESPN+, and Hulu for a discounted price. Available with Hulu (With Ads) for $12.99/month or with Hulu (No Ads) for $19.99/month.\n<br>\n<br>\n<img src=\"/static/hitch/static/icons/Pricing_Checkmark_black.svg\" role=\"presentation\"> Save over $11/month compared to the current regular monthly price of each service when purchased separately.\n<br>\n<br>\n<img src=\"/static/hitch/static/icons/Pricing_Checkmark_black.svg\" role=\"presentation\"> Enjoy all your favorite shows, movies, sports, and more using the Disney+, Hulu, and ESPN+ apps (or sites, for those on a browser). Download each app separately to access each service.\n<br>\n<br>\n<img src=\"/static/hitch/static/icons/Pricing_Checkmark_black.svg\" role=\"presentation\"> Cancel anytime.\n<br>\n<br>\nSavings compared to current regular monthly price for each service.\n<br><br>\n<div class=\"value-prop-disclaimer\">&nbsp;</div>",
+			"modalTitle": "",
+			"id": "bundle_details",
+			"metrics": {}
+		},
+		{
+			"type": "html_module",
+			"html_code": "<style type=\"text/css\">\n @media screen and (max-width: 768px) {\n  .DetailEntityMetadata {\n    display: none;\n  }\n  .DetailEntityMasthead__disclaimer {\n    display:block;\n  }\n}\n</style>",
+			"metrics": {}
+		}
+				],
+				"detailEntity": {
+		"type": "series",
+		"id": "c0bba144-1fa6-4ee5-affc-1029c77cfb71",
+		"name": "Tengoku Daimakyo",
+		"description": "In the year 2024, grotesque monsters lurk amongst the ruins of Japan, while remaining people scrape together what they can to survive. Kiruko accepts a mysterious woman's dying wish to take a boy named Maru to a place called Heaven.",
+		"network": "Hulu Original Series",
+		"premiereDate": "2023-04-01T05:00:00Z",
+		"artwork": {
+			"horizontalProgramTile": {
+				"path": "https://img1.hulu.com/user/v3/artwork/c0bba144-1fa6-4ee5-affc-1029c77cfb71?base_image_bucket_name=image_manager&base_image=7f6399a2-4cc7-46e2-81af-161f5c464107"
+			},
+			"verticalHero": {
+				"path": "https://img1.hulu.com/user/v3/artwork/c0bba144-1fa6-4ee5-affc-1029c77cfb71?base_image_bucket_name=image_manager&base_image=eb47ab4b-7489-4e1c-a3b0-18d1fe6cbe75"
+			}
+		},
+		"href": "https://www.hulu.com/series/tengoku-daimakyo-c0bba144-1fa6-4ee5-affc-1029c77cfb71",
+		"requireLivePackage": false,
+		"redirectTo": null,
+		"latestSeason": {
+			"firstEpPremiereDate": null,
+			"lastEpPremiereDate": null,
+			"season": "1",
+			"seasonPremiereDates": [],
+			"previousSeason": "1",
+			"hasContentAvailable": false
+		},
+		"credits": null,
+		"latestTrailer": {
+			"title": "Tengoku Daimakyo Trailer",
+			"eabId": "EAB::39a449cc-02f1-4520-a37f-10198ef6e437::61724508::231364813",
+			"duration": "PT108S",
+			"uploadDate": "2023-04-29T04:00:00Z"
+		}
+				},
+				"metrics": {
+		"collectionCount": 4
+				},
+				"options": {
+		"enableBrand": false,
+		"enableHotjar": false,
+		"ctaMobileFlag": false,
+		"ctaAnonCopy": null,
+		"ctaAnonLink": null,
+		"ctaAllCopy": null,
+		"ctaAllLink": null,
+		"ctaSomeCopy": null,
+		"ctaSomeLink": null,
+		"ctaSomeNotToAddonCopy": null,
+		"ctaSomeNotToAddonLink": null,
+		"ctaSomeAndNotEnrolledCopy": null,
+		"ctaSomeAndNotEnrolledLink": null,
+		"ctaIneligibleCopy": null,
+		"ctaIneligibleLink": null,
+		"ctaInactiveCopy": null,
+		"ctaInactiveLink": null,
+		"ctaAppleCopy": null,
+		"ctaAppleLink": null,
+		"cartAbandonmentCopy": {
+			"planAndNameCopy": null,
+			"nameCopy": null,
+			"planCopy": null,
+			"defaultCopy": null,
+			"href": null
+		},
+		"disableFooter": null,
+		"displayTheme": null,
+		"pageType": "landing",
+		"allowSubscriberTraffic": false,
+		"shouldCheckForPrepaid": false,
+		"cohortCheck": false,
+		"checkProgramWindow": false,
+		"footer": null,
+		"contentOverrides": {
+			"overrideName": null,
+			"overrideDescription": null
+		}
+				},
+				"program": {
+		"partner": null,
+		"hiswitchPackages": null,
+		"type": null
+				},
+				"requireLivePackage": false,
+				"redirectTo": null,
+				"metatags": [
+		{
+			"value": "Watch Tengoku Daimakyo Streaming Online | Hulu (Free Trial)",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "title"
+		},
+		{
+			"value": "Start your free trial to watch Tengoku Daimakyo and other popular TV shows and movies including new releases, classics, Hulu Originals, and more. It’s all on Hulu.",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "description"
+		},
+		{
+			"value": "https://www.hulu.com/series/tengoku-daimakyo-c0bba144-1fa6-4ee5-affc-1029c77cfb71",
+			"valueName": "href",
+			"keyName": "rel",
+			"tag": "link",
+			"key": "canonical"
+		},
+		{
+			"value": "en-US",
+			"valueName": "content",
+			"keyName": "httpEquiv",
+			"tag": "meta",
+			"key": "content-language"
+		},
+		{
+			"value": "text/html; charset=UTF-8",
+			"valueName": "content",
+			"keyName": "httpEquiv",
+			"tag": "meta",
+			"key": "content-type"
+		},
+		{
+			"value": "ie=edge",
+			"valueName": "content",
+			"keyName": "httpEquiv",
+			"tag": "meta",
+			"key": "x-ua-compatible"
+		},
+		{
+			"value": "web-nonsub",
+			"valueName": "content",
+			"keyName": "property",
+			"tag": "meta",
+			"key": "cu_app"
+		},
+		{
+			"value": "Hulu",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "application-name"
+		},
+		{
+			"value": "40582213222",
+			"valueName": "content",
+			"keyName": "property",
+			"tag": "meta",
+			"key": "fb:app_id"
+		},
+		{
+			"value": "width",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "MobileOptimized"
+		},
+		{
+			"value": "true",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "HandheldFriendly"
+		},
+		{
+			"value": "width=device-width, initial-scale=1.0",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "viewport"
+		},
+		{
+			"value": "Hulu",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "application-name"
+		},
+		{
+			"value": "App",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "msApplication-ID"
+		},
+		{
+			"value": "/",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "msapplication-starturl"
+		},
+		{
+			"value": "#ffffff",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "msapplication-tilecolor"
+		},
+		{
+			"value": "/icon-win8-tile.png",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "msapplication-tileimage"
+		},
+		{
+			"value": "Start Hulu with Internet Explorer enhancements.",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "msapplication-tooltip"
+		},
+		{
+			"value": "HuluLLC.HuluPlus_fphbd361v8tya",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "msApplication-PackageFamilyName"
+		},
+		{
+			"value": "3",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "cmsversion"
+		},
+		{
+			"value": "summary",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "twitter:card"
+		},
+		{
+			"value": "Tengoku Daimakyo",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "twitter:title"
+		},
+		{
+			"value": "@Hulu",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "twitter:site"
+		},
+		{
+			"value": "In the year 2024, grotesque monsters lurk amongst the ruins of Japan, while remaining people scrape together what they can to survive. Kiruko accepts a mysterious woman's dying wish to take a boy named Maru to a place called Heaven.",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "twitter:description"
+		},
+		{
+			"value": "https://www.hulu.com/series/tengoku-daimakyo-c0bba144-1fa6-4ee5-affc-1029c77cfb71",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "twitter:url"
+		},
+		{
+			"value": "https://img1.hulu.com/user/v3/artwork/c0bba144-1fa6-4ee5-affc-1029c77cfb71?base_image_bucket_name=image_manager&base_image=7f6399a2-4cc7-46e2-81af-161f5c464107&size=1200x630&format=jpeg&operations=%5B%7B%22gradient_vector%22%3A%22(0%2C0%2C0%2C0.5)%7C(0%2C0%2C0%2C0)%7C(0%2C600)%7C(0%2C240)%22%7D%2C%7B%22overlay%22%3A%7B%22position%22%3A%22SouthEast%7C(30%2C30)%22%2C%22operations%22%3A%5B%7B%22image%22%3A%22image_manager%7C5d7f53a9-b8bf-4731-887a-0a87c4628439%22%7D%2C%7B%22resize%22%3A%22204x204%7Cmax%22%7D%2C%7B%22extent%22%3A%22204x204%22%7D%5D%7D%7D%2C%5D",
+			"valueName": "content",
+			"keyName": "name",
+			"tag": "meta",
+			"key": "twitter:image"
+		},
+		{
+			"value": "15033883",
+			"valueName": "content",
+			"keyName": "property",
+			"tag": "meta",
+			"key": "twitter:account_id"
+		},
+		{
+			"value": "https://img1.hulu.com/user/v3/artwork/c0bba144-1fa6-4ee5-affc-1029c77cfb71?base_image_bucket_name=image_manager&base_image=7f6399a2-4cc7-46e2-81af-161f5c464107&size=1200x630&format=jpeg&operations=%5B%7B%22gradient_vector%22%3A%22(0%2C0%2C0%2C0.5)%7C(0%2C0%2C0%2C0)%7C(0%2C600)%7C(0%2C240)%22%7D%2C%7B%22overlay%22%3A%7B%22position%22%3A%22SouthEast%7C(30%2C30)%22%2C%22operations%22%3A%5B%7B%22image%22%3A%22image_manager%7C5d7f53a9-b8bf-4731-887a-0a87c4628439%22%7D%2C%7B%22resize%22%3A%22204x204%7Cmax%22%7D%2C%7B%22extent%22%3A%22204x204%22%7D%5D%7D%7D%2C%5D",
+			"valueName": "content",
+			"keyName": "property",
+			"tag": "meta",
+			"key": "og:image"
+		},
+		{
+			"value": "In the year 2024, grotesque monsters lurk amongst the ruins of Japan, while remaining people scrape together what they can to survive. Kiruko accepts a mysterious woman's dying wish to take a boy named Maru to a place called Heaven.",
+			"valueName": "content",
+			"keyName": "property",
+			"tag": "meta",
+			"key": "og:description"
+		},
+		{
+			"value": "https://www.hulu.com/series/tengoku-daimakyo-c0bba144-1fa6-4ee5-affc-1029c77cfb71",
+			"valueName": "content",
+			"keyName": "property",
+			"tag": "meta",
+			"key": "og:url"
+		},
+		{
+			"value": "https://www.hulu.com/series/tengoku-daimakyo-c0bba144-1fa6-4ee5-affc-1029c77cfb71",
+			"valueName": "content",
+			"keyName": "property",
+			"tag": "meta",
+			"key": "og:title"
+		},
+		{
+			"value": "Hulu",
+			"valueName": "content",
+			"keyName": "property",
+			"tag": "meta",
+			"key": "og:site_name"
+		},
+		{
+			"value": "tv_show",
+			"valueName": "content",
+			"keyName": "property",
+			"tag": "meta",
+			"key": "og:type"
+		}
+				],
+				"title": "Watch Tengoku Daimakyo Streaming Online | Hulu (Free Trial)"
+			},
+			"geodata": {
+				"geodataOverrides": {}
+			},
+			"cartAbandonment": null,
+			"isSufReturningCustomer": false,
+			"useAnalytics": true,
+			"collectionCount": 4,
+			"isHiswitch": null,
+			"userIsLoggedIn": false,
+			"userIsSubscriber": false,
+			"user": {
+				"isHuluUser": false,
+				"isSubscriber": false,
+				"entitlementState": 0,
+				"entitlementFlag": true,
+				"isAppleBilled": false,
+				"name": ""
+			},
+			"config": {
+				"appComponentName": "hitch",
+				"gaEnv": "prod",
+				"tealiumEnv": "prod",
+				"disableRecaptcha": false,
+				"loginModalEnv": "prod",
+				"webLoginEnv": "prod",
+				"datadogRum": {
+		"applicationId": "33d824b1-a6ca-43c8-8ce7-2d38b47f4a5c",
+		"clientToken": "pub016bdb84b22c0458131a5fda78a720df"
+				},
+				"endpoints": {
+		"ballyhoo": "https://ballyhoo.prod.hulu.com",
+		"splat": "https://subplatform.prod.hulu.com",
+		"signup": "https://signup.hulu.com",
+		"hoth": "https://auth.hulu.com",
+		"hudis": "https://secure.hulu.com",
+		"site": "https://www.hulu.com",
+		"home": "https://home.hulu.com",
+		"hookup": "http://hookup-cannonball.prod.hulu.com",
+		"user_model": "http://user-model.prod.hulu.com",
+		"midgard": "http://midgard.prod.hulu.com"
+				},
+				"keys": {
+		"facebook_app_id": "40582213222"
+				},
+				"huluEnv": "production"
+			},
+			"isAppsFlyer": false
+		}
+	},
+	"page": "/BrowsePage",
+	"query": {
+		"entity": "series",
+		"id": "tengoku-daimakyo-c0bba144-1fa6-4ee5-affc-1029c77cfb71"
+	},
+	"buildId": "yNq7M_-ydIs4xwJ9Lddri",
+	"assetPrefix": "/static/hitch",
+	"runtimeConfig": {
+		"appComponentName": "hitch",
+		"gaEnv": "prod",
+		"tealiumEnv": "prod",
+		"disableRecaptcha": false,
+		"loginModalEnv": "prod",
+		"webLoginEnv": "prod",
+		"datadogRum": {
+			"applicationId": "33d824b1-a6ca-43c8-8ce7-2d38b47f4a5c",
+			"clientToken": "pub016bdb84b22c0458131a5fda78a720df"
+		},
+		"endpoints": {
+			"ballyhoo": "https://ballyhoo.prod.hulu.com",
+			"splat": "https://subplatform.prod.hulu.com",
+			"signup": "https://signup.hulu.com",
+			"hoth": "https://auth.hulu.com",
+			"hudis": "https://secure.hulu.com",
+			"site": "https://www.hulu.com",
+			"home": "https://home.hulu.com",
+			"hookup": "http://hookup-cannonball.prod.hulu.com",
+			"user_model": "http://user-model.prod.hulu.com",
+			"midgard": "http://midgard.prod.hulu.com"
+		},
+		"keys": {
+			"facebook_app_id": "40582213222"
+		},
+		"huluEnv": "production"
+	},
+	"isFallback": false,
+	"customServer": true,
+	"gip": true,
+	"appGip": true
+   }

--- a/examples/hulu-scrape_multiple_seasons.json
+++ b/examples/hulu-scrape_multiple_seasons.json
@@ -1,0 +1,8336 @@
+{
+	"props": {
+		"pageProps": {
+			"pageTitle": "Watch Attack on Titan Streaming Online | Hulu (Free Trial)",
+			"asPath": "/series/attack-on-titan-9c91ffa3-dc20-48bf-8bc5-692e37c76d88",
+			"pageType": "BrowsePage",
+			"query": {
+				"entity": "series",
+				"id": "attack-on-titan-9c91ffa3-dc20-48bf-8bc5-692e37c76d88"
+			},
+			"appsFlyerBannerKey": "",
+			"_sentryTraceData": "ce918cbcd1ed4a91acc39537c411f035-bb95792b767ee9d8-1",
+			"_sentryBaggage": "sentry-environment=production,sentry-release=hitch%402.33.0,sentry-public_key=dfddf0aabbab4be4937d4082aad36bab,sentry-trace_id=ce918cbcd1ed4a91acc39537c411f035,sentry-sample_rate=0.05",
+			"latestSeason": {
+				"season": "4",
+				"previousSeason": "3",
+				"hasUpcomingSeason": false,
+				"hasLastEpPremiered": true
+			},
+			"featureFlags": {
+				"has404CarouselEnabled": true,
+				"hasConnectedAuthEnabled": true,
+				"hasUnifiedLoginEnabled": true,
+				"hasUpdatedGenderOptions": true,
+				"hasOneTrustScriptEnabled": false,
+				"hasOneTrustFooterChangeActivated": false,
+				"hasSubscriberAgreementUpdateEnabled": true
+			},
+			"layout": {
+				"locale": "en-US",
+				"bigFooter": [
+					{
+						"sections": [
+							{
+								"section": "BROWSE",
+								"items": [
+									[
+										{
+											"link": "/content",
+											"title": "Streaming Library"
+										},
+										{
+											"link": "/live-tv",
+											"title": "Live TV"
+										},
+										{
+											"link": "/live-news",
+											"title": "Live News"
+										},
+										{
+											"link": "/live-sports",
+											"title": "Live Sports"
+										}
+									],
+									[
+										{
+											"link": "/hub/tv",
+											"title": "TV Shows"
+										},
+										{
+											"link": "/hub/movies",
+											"title": "Movies"
+										},
+										{
+											"link": "/hub/originals",
+											"title": "Originals"
+										},
+										{
+											"link": "/hub/networks",
+											"title": "Networks"
+										},
+										{
+											"link": "/hub/kids",
+											"title": "Kids"
+										},
+										{
+											"link": "/fx-on-hulu",
+											"title": "FX"
+										}
+									],
+									[
+										{
+											"link": "/max",
+											"title": "Max"
+										},
+										{
+											"link": "/cinemax",
+											"title": "Cinemax"
+										},
+										{
+											"link": "/showtime",
+											"title": "Showtime"
+										},
+										{
+											"link": "/starz",
+											"title": "STARZ"
+										}
+									],
+									[
+										{
+											"link": "/hulu-disney-espn-bundle-offer",
+											"title": "Disney Bundle Trio Basic"
+										},
+										{
+											"link": "/disney-bundle-hulu-no-ads",
+											"title": "Disney Bundle Trio Premium"
+										},
+										{
+											"link": "/disney-bundle-duo-basic",
+											"title": "Disney Bundle Duo Basic"
+										},
+										{
+											"link": "/student",
+											"title": "Student Discount"
+										}
+									]
+								]
+							},
+							{
+								"section": "HELP",
+								"items": [
+									[
+										{
+											"link": "//help.hulu.com/s/article/manage-subscription",
+											"title": "Account & Billing"
+										},
+										{
+											"link": "//help.hulu.com/s/article/how-much-does-hulu-cost",
+											"title": "Plans & Pricing"
+										},
+										{
+											"link": "//help.hulu.com/s/article/supported-devices",
+											"title": "Supported Devices"
+										},
+										{
+											"link": "//help.hulu.com/s/article/accessibility-features",
+											"title": "Accessibility"
+										}
+									]
+								]
+							},
+							{
+								"section": "ABOUT US",
+								"items": [
+									[
+										{
+											"link": "#hulushop",
+											"title": "Shop Hulu",
+											"modalId": "hulushop"
+										},
+										{
+											"link": "/press",
+											"title": "Press"
+										},
+										{
+											"link": "/jobs",
+											"title": "Jobs"
+										},
+										{
+											"link": "//help.hulu.com/s/article/how-to-contact-Hulu",
+											"title": "Contact"
+										}
+									]
+								]
+							}
+						],
+						"modals": [
+							{
+								"title": "Next stop: Shop Hulu, powered by Snowcommerce",
+								"id": "hulushop",
+								"css_class": "modal-dialog__default-display modal-dialog__size-small",
+								"closable": true,
+								"body": "<div class=\"HuluShopModal\">You are about to exit Hulu.com to visit the Shop Hulu site, where a different Terms of Use and Privacy Policy apply. Please note that the Shop Hulu site is owned and operated by Snowcommerce.<div class=\"modal-dialog__actions\"><a href=\"https://shop.hulu.com/?utm_source=hulu-com&utm_medium=referral&utm_campaign=hulu-footer\"><button class=\"button--cta button--black\">CONTINUE</button></a><button class=\"button--cta button--white\" onClick=\"document.getElementById('hulushop').getElementsByClassName('modal--close')[0].click()\">CANCEL</button></div></div>",
+								"footer": ""
+							}
+						]
+					}
+				],
+				"bundle": {
+					"amount": null
+				},
+				"components": [
+					{
+						"type": "navigation",
+						"style": null,
+						"sticky_mode": null,
+						"cta_always": true,
+						"enable_cta_toaster": null,
+						"enableMinimalNav": false,
+						"items": [],
+						"cta": "Start Your Free Trial",
+						"cta_button_style": "black",
+						"disable_logo": null,
+						"signup_flow_entry": "/signup/go/one-hulu",
+						"ctaDownloadAppText": null,
+						"welcomeOptions": "",
+						"enableStickyModeAlways": null,
+						"metrics": {}
+					},
+					{
+						"type": "detailentity_masthead",
+						"avFeatures": {
+							"items": [
+								"hd"
+							],
+							"truncatedItems": [
+								"hd"
+							]
+						},
+						"credits": [
+							{
+								"prefix": "Starring:",
+								"seoSchemaProp": "actor",
+								"items": [
+									"Yûki Kaji",
+									"Yui Ishikawa",
+									"Marina Inoue",
+									"Kisho Taniyama",
+									"Yu Shimamura"
+								],
+								"truncatedItems": [
+									"Yûki Kaji",
+									"Yui Ishikawa",
+									"Marina Inoue"
+								]
+							}
+						],
+						"disablePlayButton": false,
+						"disableMobilePlayButton": false,
+						"title": "Attack on Titan",
+						"entityId": "9c91ffa3-dc20-48bf-8bc5-692e37c76d88",
+						"description": "From the director of Death Note comes Attack on Titan. Many years ago, humanity was forced to retreat behind the towering walls of a fortified city to escape the massive, man-eating Titans that roamed the land outside their fortress. This is their story.",
+						"entityType": "series",
+						"backgroundArtwork": {
+							"path": "https://img3.hulu.com/user/v3/artwork/9c91ffa3-dc20-48bf-8bc5-692e37c76d88?base_image_bucket_name=image_manager&base_image=ca0b85ac-b988-4231-8c53-396406e9e64d",
+							"hue": 20
+						},
+						"brandArtwork": null,
+						"verticalTileArtwork": {
+							"path": "https://img3.hulu.com/user/v3/artwork/9c91ffa3-dc20-48bf-8bc5-692e37c76d88?base_image_bucket_name=image_manager&base_image=0d6eb2f9-891d-4076-8ce9-22a297b9f2ca",
+							"hue": 25
+						},
+						"titleArtwork": {
+							"path": "https://img3.hulu.com/user/v3/artwork/9c91ffa3-dc20-48bf-8bc5-692e37c76d88?base_image_bucket_name=image_manager&base_image=6704b395-0845-4820-a507-a9b9be1d5e84"
+						},
+						"headline": [
+							"4 seasons available (175 episodes)"
+						],
+						"isHuluOriginal": false,
+						"tags": [
+							2013
+						],
+						"trailerText": "Watch Trailer",
+						"trailerName": "Attack on Titan Final Season Part 2 - PV 2",
+						"trailerEAB": "EAB::a2ee9bf4-37c5-4720-801c-ed5d88ea11b3::61703763::176894325",
+						"trailerId": "a2ee9bf4-37c5-4720-801c-ed5d88ea11b3",
+						"requirePremium": false,
+						"network": "Crunchyroll",
+						"isHuluOriginalContent": false,
+						"isOriginalContent": false,
+						"premiereDate": "2013-04-07T00:00:00Z",
+						"rating": "TVMA",
+						"genres": [
+							{
+								"name": "Action",
+								"hubPath": "/hub/action-tv"
+							},
+							{
+								"name": "Animation",
+								"hubPath": null
+							},
+							{
+								"name": "Fantasy",
+								"hubPath": "/hub/fantasy-tv"
+							},
+							{
+								"name": "International",
+								"hubPath": "/hub/international-tv"
+							},
+							{
+								"name": "Anime",
+								"hubPath": "/hub/anime-tv"
+							}
+						],
+						"disclaimer": "Stream thousands of shows and movies, with plans starting at $7.99/month.",
+						"ctaText": "Start Your Free Trial",
+						"ctaUrl": "/signup/go/one-hulu",
+						"legalText": "New subscribers only. Cancel anytime. Additional terms apply.",
+						"ctaDownloadAppText": "Watch Now With The Hulu App",
+						"infoLine": "4 seasons available (175 episodes)",
+						"disableInfo": false,
+						"contentType": "series",
+						"ribbon": {
+							"ribbonImage": "//cnbl-cdn.bamgrid.com/assets/1afce5041391d18ddcca64656450cce9664bc80d0618344d06ff6dcf005775e8/original",
+							"eyebrow": "DISNEY BUNDLE TRIO BASIC",
+							"buttonLink": "/signup/go/one-hulu?tab=bundles",
+							"buttonStyle": "white",
+							"buttonText": "GET ALL THREE",
+							"legalModalId": "",
+							"legalLink": "/terms/disneybundle/duotrio",
+							"legalText": "Terms apply",
+							"mainTextDt": "Get Hulu, Disney+, and ESPN+, all with ads, for $12.99/mo.",
+							"mainTextMobile": "Get Hulu, Disney+, and ESPN+, all with ads, for $12.99/mo.",
+							"learnMore": "",
+							"learnText": "",
+							"backgroundStyle": "blackTransparent"
+						},
+						"metrics": {}
+					},
+					{
+						"type": "collection_tabs",
+						"accentColor": "hsla(20, 100%, 60%, 1)",
+						"networkLogo": null,
+						"includeHeroSlider": false,
+						"shouldCenterTabTitles": false,
+						"tabs": [
+							{
+								"title": "Episodes",
+								"model": {
+									"type": "episode_collection",
+									"collection": {
+										"id": "94",
+										"href": "https://discover.hulu.com/content/v5/hubs/series/9c91ffa3-dc20-48bf-8bc5-692e37c76d88/collections/94?schema=0&personalized_layout_id=H4sIAAAAAAAAAMu1MjIwMjYwMzAxNDcwrykptjI0szC1sLQwMTIAAgAi8yitHwAAAA",
+										"name": "Episodes",
+										"theme": "episode_collection",
+										"enabledTileLinks": false,
+										"enableSignupModal": null,
+										"collectionHubPath": null,
+										"seasons": [
+											{
+												"name": "Season 1",
+												"number": 1
+											},
+											{
+												"name": "Season 2",
+												"number": 2
+											},
+											{
+												"name": "Season 3",
+												"number": 3
+											},
+											{
+												"name": "Season 4",
+												"number": 4
+											}
+										],
+										"items": [
+											{
+												"id": "03f9f5bf-2add-4c27-be58-c93ae518e8ea",
+												"href": null,
+												"eabId": "EAB::03f9f5bf-2add-4c27-be58-c93ae518e8ea::60870845::183890678",
+												"type": "episode",
+												"name": "(Dub) To You, in 2000 Years / The Fall of Shiganshina, Part 1",
+												"description": "After 100 years of peace, humanity is suddenly reminded of the terror of being at the Titans' mercy.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-04-07T12:00:00Z",
+												"season": 1,
+												"number": 1,
+												"duration": 1561,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/03f9f5bf-2add-4c27-be58-c93ae518e8ea?base_image_bucket_name=image_manager&base_image=d29d4430-7c5b-4e70-93c6-602b6c6458ca",
+														"hue": 0
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "ad4b7bd5-3102-4a67-9362-ee12cbcb4e84",
+												"href": null,
+												"eabId": "EAB::ad4b7bd5-3102-4a67-9362-ee12cbcb4e84::60211296::195956942",
+												"type": "episode",
+												"name": "(Sub) To You, in 2000 Years/The Fall of Shiganshina, Part 1",
+												"description": "After 100 years of peace, humanity is suddenly reminded of the terror of being at the Titans' mercy.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-04-07T12:00:00Z",
+												"season": 1,
+												"number": 1,
+												"duration": 1462,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/ad4b7bd5-3102-4a67-9362-ee12cbcb4e84?base_image_bucket_name=image_manager&base_image=9bd35fbb-9c90-43e2-baed-3b43356afebf",
+														"hue": 0
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "039ca8e0-6a93-46cb-af94-9c013ca23a74",
+												"href": null,
+												"eabId": "EAB::039ca8e0-6a93-46cb-af94-9c013ca23a74::61087259::23111387",
+												"type": "episode",
+												"name": "(Dub) Beast Titan",
+												"description": "Coupled with the military's cover up of a previous incident, the shocking discovery inside the wall causes a stir. Elsewhere, while the new Scout recruits are held for observation, a surprising threat appears.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-04-01T12:30:00Z",
+												"season": 2,
+												"number": 1,
+												"duration": 1393,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/039ca8e0-6a93-46cb-af94-9c013ca23a74?base_image_bucket_name=image_manager&base_image=0f72a408-ebaf-42f4-a5de-fa0946d810ef",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "406774fe-7a9f-4b4a-95c8-285fa70e917b",
+												"href": null,
+												"eabId": "EAB::406774fe-7a9f-4b4a-95c8-285fa70e917b::60866945::2775390",
+												"type": "episode",
+												"name": "(Sub) Beast Titan",
+												"description": "Coupled with the military's cover-up of a previous incident, the shocking discovery inside the wall causes a stir. Elsewhere, while the new Scout recruits are held for observation, a surprising threat appears.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-04-01T12:00:00Z",
+												"season": 2,
+												"number": 1,
+												"duration": 1473,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/406774fe-7a9f-4b4a-95c8-285fa70e917b?base_image_bucket_name=image_manager&base_image=0b3e23ef-aed5-481c-8bbb-002eb5d18cae",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "cf6ae05e-6e2a-42a9-986a-3c66bf05948c",
+												"href": null,
+												"eabId": "EAB::cf6ae05e-6e2a-42a9-986a-3c66bf05948c::61384202::64515078",
+												"type": "episode",
+												"name": "(Dub) Smoke Signal",
+												"description": "Eren recovers and undergoes testing on his Titan abilities; the scouts learn a threat from within the government may destroy their operation.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-07-22T12:00:00Z",
+												"season": 3,
+												"number": 1,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/cf6ae05e-6e2a-42a9-986a-3c66bf05948c?base_image_bucket_name=image_manager&base_image=4908812c-630f-488e-a3c2-4e862795406a",
+														"hue": 30
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "b57797d6-7da0-447f-b4fc-16af12bc069b",
+												"href": null,
+												"eabId": "EAB::b57797d6-7da0-447f-b4fc-16af12bc069b::61155782::31033774",
+												"type": "episode",
+												"name": "(Sub) Smoke Signal",
+												"description": "After barely surviving Eren's recovery, a rising threat from the shadows puts everyone's lives in danger again.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-07-22T12:00:00Z",
+												"season": 3,
+												"number": 1,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/b57797d6-7da0-447f-b4fc-16af12bc069b?base_image_bucket_name=image_manager&base_image=ae038d0d-bd25-461a-9438-9c9038dea09f",
+														"hue": 30
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "9cd961dd-22f4-4527-95b9-993be7e65a5e",
+												"href": null,
+												"eabId": "EAB::9cd961dd-22f4-4527-95b9-993be7e65a5e::61694681::166829933",
+												"type": "episode",
+												"name": "(Dub) The Other Side of the Sea",
+												"description": "As Marley battles the Mid-East Alliance to end a four-year war, a group of Warrior candidates on the front lines compete to be the successor of the Armored Titan.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2020-12-06T12:00:00Z",
+												"season": 4,
+												"number": 1,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/9cd961dd-22f4-4527-95b9-993be7e65a5e?base_image_bucket_name=image_manager&base_image=ce3787f7-be3c-47a4-b82f-49bc068c383b",
+														"hue": 25
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "1c69f4d3-6d77-4ff9-a5ab-7a6e9257eb3b",
+												"href": null,
+												"eabId": "EAB::1c69f4d3-6d77-4ff9-a5ab-7a6e9257eb3b::61605912::117885537",
+												"type": "episode",
+												"name": "(Sub) The Other Side of the Sea",
+												"description": "As Marley battles the Mid-East Alliance to end a four-year war, a group of Warrior candidates on the front lines compete to be the successor of the Armored Titan.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2020-12-06T12:00:00Z",
+												"season": 4,
+												"number": 1,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/1c69f4d3-6d77-4ff9-a5ab-7a6e9257eb3b?base_image_bucket_name=image_manager&base_image=08616a3f-23a9-4a06-b90a-daf08bec66d5",
+														"hue": 25
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "e5bf6070-1e58-4bc0-b725-776f5f46cc42",
+												"href": null,
+												"eabId": "EAB::e5bf6070-1e58-4bc0-b725-776f5f46cc42::60870844::3146713",
+												"type": "episode",
+												"name": "(Dub) That Day: The Fall of Shiganshina, Part 2",
+												"description": "That Day: The Fall of Shiganshina, Part 2: After the Titans break through the wall, the citizens of Shiganshina must run for their lives. Those that do make it to safety find a harsh life waiting for them, however.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-04-14T00:00:00Z",
+												"season": 1,
+												"number": 2,
+												"duration": 1471,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/e5bf6070-1e58-4bc0-b725-776f5f46cc42?base_image_bucket_name=image_manager&base_image=d57b2f39-4603-4a72-a83a-8d51ce642a3b",
+														"hue": 15
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "cf3e621a-bdc1-431f-8518-d4d95be4e393",
+												"href": null,
+												"eabId": "EAB::cf3e621a-bdc1-431f-8518-d4d95be4e393::60211297::195957048",
+												"type": "episode",
+												"name": "(Sub) That Day: The Fall of Shiganshina, Part 2",
+												"description": "After the Titans break through the wall, the citizens of Shiganshina must run for their lives. Those that do make it to safety find a harsh life waiting for them, however.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-04-14T00:00:00Z",
+												"season": 1,
+												"number": 2,
+												"duration": 1462,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/cf3e621a-bdc1-431f-8518-d4d95be4e393?base_image_bucket_name=image_manager&base_image=2ebceafb-e8a0-441b-8a3d-74d7efa37bd2",
+														"hue": 15
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "7049b7fa-30ec-4b0c-acbe-1e3c86d1c127",
+												"href": null,
+												"eabId": "EAB::7049b7fa-30ec-4b0c-acbe-1e3c86d1c127::61087260::183883034",
+												"type": "episode",
+												"name": "(Dub) I'm Home",
+												"description": "With the appearance of Titans within Wall Rose, Sasha and Conny ride as messengers to warn their villages of the impending threat.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-04-08T00:00:00Z",
+												"season": 2,
+												"number": 2,
+												"duration": 1393,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/7049b7fa-30ec-4b0c-acbe-1e3c86d1c127?base_image_bucket_name=image_manager&base_image=1333f6c1-0962-432c-8ad3-4340f3fa11c0",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "9c397517-1996-4efa-b8be-cc0899945e0a",
+												"href": null,
+												"eabId": "EAB::9c397517-1996-4efa-b8be-cc0899945e0a::60870815::2877469",
+												"type": "episode",
+												"name": "(Sub) I'm Home",
+												"description": "With the appearance of Titans within Wall Rose, Sasha and Conny ride as messengers to warn their villages of the impending threat.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-04-08T12:00:00Z",
+												"season": 2,
+												"number": 2,
+												"duration": 1473,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/9c397517-1996-4efa-b8be-cc0899945e0a?base_image_bucket_name=image_manager&base_image=729d20b4-09e4-421c-ae11-587651eb9b00",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "8455fcc1-d52a-4061-a471-784ed009acbd",
+												"href": null,
+												"eabId": "EAB::8455fcc1-d52a-4061-a471-784ed009acbd::61383896::64515095",
+												"type": "episode",
+												"name": "(Dub) Pain",
+												"description": "The Scouts take a stand against a new enemy, but it's not just Titans they'll be fighting anymore.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-07-29T00:00:00Z",
+												"season": 3,
+												"number": 2,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/8455fcc1-d52a-4061-a471-784ed009acbd?base_image_bucket_name=image_manager&base_image=c7233b39-f892-48da-902b-85fd9116e3d8",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "6ccbfce8-d4df-495e-8141-215033d38853",
+												"href": null,
+												"eabId": "EAB::6ccbfce8-d4df-495e-8141-215033d38853::61160124::31673442",
+												"type": "episode",
+												"name": "(Sub) Pain",
+												"description": "The Scouts take a stand against a new enemy, but it's not just Titans they'll be fighting anymore.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-07-29T12:00:00Z",
+												"season": 3,
+												"number": 2,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/6ccbfce8-d4df-495e-8141-215033d38853?base_image_bucket_name=image_manager&base_image=37147fb6-fae2-4950-bc1e-4d516d4743b6",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "7273b806-5e7f-4f25-8ef0-3758d0ba9a7e",
+												"href": null,
+												"eabId": "EAB::7273b806-5e7f-4f25-8ef0-3758d0ba9a7e::61694719::166829965",
+												"type": "episode",
+												"name": "(Dub) Midnight Train",
+												"description": "Though glad the war is over, both the Eldian Warriors and Marley brass realize that neither have a future unless they finish the job of retaking the Founding Titan.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2020-12-13T20:00:00Z",
+												"season": 4,
+												"number": 2,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/7273b806-5e7f-4f25-8ef0-3758d0ba9a7e?base_image_bucket_name=image_manager&base_image=48531571-fce3-4e06-b947-d31aba317f38",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "a7e72471-d229-449a-9e05-4faef5b8677c",
+												"href": null,
+												"eabId": "EAB::a7e72471-d229-449a-9e05-4faef5b8677c::61608157::118549359",
+												"type": "episode",
+												"name": "(Sub) Midnight Train",
+												"description": "Though glad the war is over, both the Eldian Warriors and Marley brass realize that neither have a future unless they finish the job of retaking the Founding Titan.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2020-12-13T12:00:00Z",
+												"season": 4,
+												"number": 2,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/a7e72471-d229-449a-9e05-4faef5b8677c?base_image_bucket_name=image_manager&base_image=27e8d91d-fe16-46a2-91f4-511066b32f42",
+														"hue": 200
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "248c05ae-52aa-4424-8bf5-5d36230c1421",
+												"href": null,
+												"eabId": "EAB::248c05ae-52aa-4424-8bf5-5d36230c1421::60870835::3146699",
+												"type": "episode",
+												"name": "(Dub) A Dim Light Amid Despair: Humanity's Comeback, Part 1",
+												"description": "Dim Light Amid Despair: Humanity's Comeback, Part 1, A: Eren begins his training with the Cadet Corps, but questions about his painful past overwhelm him. When he struggles with a maneuvering exercise, Berholt and Reiner offer kindly advice.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-04-21T00:00:00Z",
+												"season": 1,
+												"number": 3,
+												"duration": 1471,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/248c05ae-52aa-4424-8bf5-5d36230c1421?base_image_bucket_name=image_manager&base_image=6601ea32-d992-41c9-a783-871239cf927a",
+														"hue": 205
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "4cd43f4d-13fd-4624-a169-a958481e1383",
+												"href": null,
+												"eabId": "EAB::4cd43f4d-13fd-4624-a169-a958481e1383::60211298::195962117",
+												"type": "episode",
+												"name": "(Sub) A Dim Light Amid Despair / Humanity's Comeback, Part 1",
+												"description": "Eren begins his training with the Cadet Corps, but questions about his painful past overwhelm him. When he struggles with a maneuvering exercise, Berholt and Reiner offer kindly advice.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-04-21T12:00:00Z",
+												"season": 1,
+												"number": 3,
+												"duration": 1462,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/4cd43f4d-13fd-4624-a169-a958481e1383?base_image_bucket_name=image_manager&base_image=f3d155ce-a864-47d6-a0e6-f36f5ab61ae4",
+														"hue": 205
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "fe3ce843-7127-4813-a93f-66c75e9f3d47",
+												"href": null,
+												"eabId": "EAB::fe3ce843-7127-4813-a93f-66c75e9f3d47::61087265::23111324",
+												"type": "episode",
+												"name": "(Dub) Southwestward",
+												"description": "The Scouts search for a hole in the wall while Eren and the others learn that someone close may be hiding all the answers.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-04-15T00:00:00Z",
+												"season": 2,
+												"number": 3,
+												"duration": 1393,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/fe3ce843-7127-4813-a93f-66c75e9f3d47?base_image_bucket_name=image_manager&base_image=4890c596-4d08-4dd5-90af-430d25ca258c",
+														"hue": 40
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "975af6c0-3a8c-477b-b82d-1970c4adc8cf",
+												"href": null,
+												"eabId": "EAB::975af6c0-3a8c-477b-b82d-1970c4adc8cf::60874666::3067190",
+												"type": "episode",
+												"name": "(Sub) Southwestward",
+												"description": "The Scouts search for a hole in the wall while Eren and the others learn that someone close may be hiding all the answers.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-04-15T12:00:00Z",
+												"season": 2,
+												"number": 3,
+												"duration": 1473,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/975af6c0-3a8c-477b-b82d-1970c4adc8cf?base_image_bucket_name=image_manager&base_image=5e35b5c2-4e45-4a2a-a8f1-538edc42a289",
+														"hue": 40
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "a6d0b116-f7a1-4285-89cb-0c079e46609f",
+												"href": null,
+												"eabId": "EAB::a6d0b116-f7a1-4285-89cb-0c079e46609f::61383964::64515081",
+												"type": "episode",
+												"name": "(Dub) Old Story",
+												"description": "Historia and Erwin look back on their past, revealing shady actions taken by the government and a motivation for change.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-08-05T00:00:00Z",
+												"season": 3,
+												"number": 3,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/a6d0b116-f7a1-4285-89cb-0c079e46609f?base_image_bucket_name=image_manager&base_image=e6f771ab-a935-4dcb-aeae-669b2b9b933f",
+														"hue": 15
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "300c02e5-d640-4a4f-a5d0-fa2f1aac65ea",
+												"href": null,
+												"eabId": "EAB::300c02e5-d640-4a4f-a5d0-fa2f1aac65ea::61163161::32081856",
+												"type": "episode",
+												"name": "(Sub) Old Story",
+												"description": "Historia and Erwin look back on their past, revealing a shady government with a hidden agenda and inspiration for an uprising.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-08-05T12:00:00Z",
+												"season": 3,
+												"number": 3,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/300c02e5-d640-4a4f-a5d0-fa2f1aac65ea?base_image_bucket_name=image_manager&base_image=72178e58-49b7-4b74-93d9-3265c028a99d",
+														"hue": 15
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "8805e9ce-5d98-42eb-9944-868e85bc7887",
+												"href": null,
+												"eabId": "EAB::8805e9ce-5d98-42eb-9944-868e85bc7887::61694724::166829936",
+												"type": "episode",
+												"name": "(Dub) The Door of Hope",
+												"description": "Reiner reflects on his past, remembering what pushed him to become a Warrior and keep moving forward when all hope was lost.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2020-12-20T20:00:00Z",
+												"season": 4,
+												"number": 3,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/8805e9ce-5d98-42eb-9944-868e85bc7887?base_image_bucket_name=image_manager&base_image=6a810a3e-ed38-4ffe-9f33-cae8500a91f9",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "7dd2866d-2cc0-409f-b3c5-d2ce9fb3d363",
+												"href": null,
+												"eabId": "EAB::7dd2866d-2cc0-409f-b3c5-d2ce9fb3d363::61610339::119237475",
+												"type": "episode",
+												"name": "(Sub) The Door of Hope",
+												"description": "Reiner reflects on his past, remembering what pushed him to become a Warrior and keep moving forward when all hope was lost.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2020-12-20T12:00:00Z",
+												"season": 4,
+												"number": 3,
+												"duration": 1457,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/7dd2866d-2cc0-409f-b3c5-d2ce9fb3d363?base_image_bucket_name=image_manager&base_image=af5093dd-459c-4db5-8e4d-b746cadc0abc",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "ffac8205-57dd-4731-a784-753400c9327f",
+												"href": null,
+												"eabId": "EAB::ffac8205-57dd-4731-a784-753400c9327f::60870850::183890661",
+												"type": "episode",
+												"name": "(Dub) Night of the Closing Ceremony / Humanity's Comeback, Part 2",
+												"description": "Humanity's Comeback, Part 2, The: Annie proves her skill in a sparring session, Jan dreams of serving alongside the King, and graduation day brings shocking revelations - along with a sudden outbreak of violence!",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-04-28T00:00:00Z",
+												"season": 1,
+												"number": 4,
+												"duration": 1471,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/ffac8205-57dd-4731-a784-753400c9327f?base_image_bucket_name=image_manager&base_image=f8d06466-7b8e-4db0-82d2-b5a758175ed8",
+														"hue": 210
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "8cdde91d-55a7-4d6a-a4fd-8ddab526c018",
+												"href": null,
+												"eabId": "EAB::8cdde91d-55a7-4d6a-a4fd-8ddab526c018::60211299::195962123",
+												"type": "episode",
+												"name": "(Sub) Night of the Closing Ceremony / Humanity's Comeback, Part 2",
+												"description": "Annie proves her skill in a sparring session, Jan dreams of serving alongside the King, and graduation day brings shocking revelations - along with a sudden outbreak of violence!",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-04-28T00:00:00Z",
+												"season": 1,
+												"number": 4,
+												"duration": 1462,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/8cdde91d-55a7-4d6a-a4fd-8ddab526c018?base_image_bucket_name=image_manager&base_image=ac80f050-8715-411c-aaea-a1edc2e71a2c",
+														"hue": 210
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "8fcb95f2-926d-4830-9e3c-d837fafc52c1",
+												"href": null,
+												"eabId": "EAB::8fcb95f2-926d-4830-9e3c-d837fafc52c1::61087266::183883035",
+												"type": "episode",
+												"name": "(Dub) Soldier",
+												"description": "Unarmed and overwhelmed by the Titan assault on the castle, the only hope for the Scouts may lie in a promise and a secret.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-04-22T00:00:00Z",
+												"season": 2,
+												"number": 4,
+												"duration": 1393,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/8fcb95f2-926d-4830-9e3c-d837fafc52c1?base_image_bucket_name=image_manager&base_image=adf61ede-2dfe-4193-ad67-e0c302b56225",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "aded8980-cfe7-4f76-890b-18d374f2eb75",
+												"href": null,
+												"eabId": "EAB::aded8980-cfe7-4f76-890b-18d374f2eb75::60878217::3263249",
+												"type": "episode",
+												"name": "(Sub) Soldier",
+												"description": "Unarmed and overwhelmed by the Titan assault on the castle, the only hope for the Scouts may lie in a promise and a secret.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-04-22T12:00:00Z",
+												"season": 2,
+												"number": 4,
+												"duration": 1473,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/aded8980-cfe7-4f76-890b-18d374f2eb75?base_image_bucket_name=image_manager&base_image=2a6280e8-f0b9-4dae-b505-3b7e4e35b508",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "314361d9-2fb5-4241-8c08-e83eb9bbc166",
+												"href": null,
+												"eabId": "EAB::314361d9-2fb5-4241-8c08-e83eb9bbc166::61383974::64515073",
+												"type": "episode",
+												"name": "(Dub) Trust",
+												"description": "On the run and running out of time, the Scouts must entrust their lives to others if they plan on surviving.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-08-12T12:00:00Z",
+												"season": 3,
+												"number": 4,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/314361d9-2fb5-4241-8c08-e83eb9bbc166?base_image_bucket_name=image_manager&base_image=0349eca7-2f49-47b4-b7b2-937e4db35881",
+														"hue": 15
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "f07ec868-07bc-4477-aa59-90ff1f1f239e",
+												"href": null,
+												"eabId": "EAB::f07ec868-07bc-4477-aa59-90ff1f1f239e::61166757::32675444",
+												"type": "episode",
+												"name": "(Sub) Trust",
+												"description": "On the run and running out of time, the Scouts must entrust their lives to others if they plan on surviving.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-08-12T12:00:00Z",
+												"season": 3,
+												"number": 4,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/f07ec868-07bc-4477-aa59-90ff1f1f239e?base_image_bucket_name=image_manager&base_image=ddd69927-fcc1-46e9-af29-6143f2685846",
+														"hue": 15
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "f6cf8993-0337-4c7c-9079-42e0a35a0807",
+												"href": null,
+												"eabId": "EAB::f6cf8993-0337-4c7c-9079-42e0a35a0807::61694727::166829931",
+												"type": "episode",
+												"name": "(Dub) From One Hand to Another",
+												"description": "A sudden visit from the Tybur family shakes up the Marleyan military. Meanwhile, Falco smuggles letters for a friend and helps two old comrades reunite.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2020-12-27T12:00:00Z",
+												"season": 4,
+												"number": 4,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/f6cf8993-0337-4c7c-9079-42e0a35a0807?base_image_bucket_name=image_manager&base_image=38da861f-bc14-4c56-88d8-fb9781dd5198",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "6083a31b-856c-4932-916e-bc7f86f5395b",
+												"href": null,
+												"eabId": "EAB::6083a31b-856c-4932-916e-bc7f86f5395b::61613208::119868603",
+												"type": "episode",
+												"name": "(Sub) From One Hand to Another",
+												"description": "A sudden visit from the Tybur family shakes up the Marleyan military. Meanwhile, Falco smuggles letters for a friend and helps two old comrades reunite.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2020-12-27T12:00:00Z",
+												"season": 4,
+												"number": 4,
+												"duration": 1457,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/6083a31b-856c-4932-916e-bc7f86f5395b?base_image_bucket_name=image_manager&base_image=d62e847a-584a-4b5e-9504-ab554d3fd7af",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "4a52f10b-cf9b-4b32-a4ff-1fb3f3f42d25",
+												"href": null,
+												"eabId": "EAB::4a52f10b-cf9b-4b32-a4ff-1fb3f3f42d25::60870849::183890668",
+												"type": "episode",
+												"name": "(Dub) First Battle / Attack on Trost, Part 1",
+												"description": "Eren faces off against the Colossal Titan after it appears out of nowhere and knocks a strategic hole in the Rose Wall gate. As Titans swarm the city, the newly graduated Cadets are called in to fight in brutal battle that won't be without casualties.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-05-05T00:00:00Z",
+												"season": 1,
+												"number": 5,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/4a52f10b-cf9b-4b32-a4ff-1fb3f3f42d25?base_image_bucket_name=image_manager&base_image=00a8bf0d-2a14-4132-b0df-f615de1283ee",
+														"hue": 190
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "782d6c23-7e01-4ed1-b5cc-b7290920b987",
+												"href": null,
+												"eabId": "EAB::782d6c23-7e01-4ed1-b5cc-b7290920b987::60214794::195962120",
+												"type": "episode",
+												"name": "(Sub) First Battle / Attack on Trost, Part 1",
+												"description": "Eren faces off against the Colossal Titan after it appears out of nowhere and knocks a strategic hole in the Rose Wall gate. As Titans swarm the city, the newly graduated Cadets are called in to fight in brutal battle that won't be without casualties.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-05-05T12:00:00Z",
+												"season": 1,
+												"number": 5,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/782d6c23-7e01-4ed1-b5cc-b7290920b987?base_image_bucket_name=image_manager&base_image=f38de326-4950-4c67-a5af-7181e76e4eba",
+														"hue": 195
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "c492cd7f-19ac-439b-98f2-944fde4cc98b",
+												"href": null,
+												"eabId": "EAB::c492cd7f-19ac-439b-98f2-944fde4cc98b::61087267::183883052",
+												"type": "episode",
+												"name": "(Dub) Historia",
+												"description": "Utgard Castle comes crumbling down as Ymir desperately battles the Titans. Now, Christa must fulfill the promise they made long ago during winter training.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-04-29T00:00:00Z",
+												"season": 2,
+												"number": 5,
+												"duration": 1393,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/c492cd7f-19ac-439b-98f2-944fde4cc98b?base_image_bucket_name=image_manager&base_image=7190a4b3-be07-4128-9300-bf651896b65c",
+														"hue": 220
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "11a7e699-c43a-46d9-a9cc-3b3e278be313",
+												"href": null,
+												"eabId": "EAB::11a7e699-c43a-46d9-a9cc-3b3e278be313::60881650::3884202",
+												"type": "episode",
+												"name": "(Sub) Historia",
+												"description": "Utgard Castle comes crumbling down as Ymir desperately battles the Titans. Now, Christa must fulfill the promise they made long ago during winter training.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-04-29T12:00:00Z",
+												"season": 2,
+												"number": 5,
+												"duration": 1473,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/11a7e699-c43a-46d9-a9cc-3b3e278be313?base_image_bucket_name=image_manager&base_image=a4f3c028-b13a-480e-8910-a85f2fa82e5b",
+														"hue": 220
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "91d5d55b-9618-48f5-a1a8-1123e30f8d3b",
+												"href": null,
+												"eabId": "EAB::91d5d55b-9618-48f5-a1a8-1123e30f8d3b::61383986::64515271",
+												"type": "episode",
+												"name": "(Dub) Reply",
+												"description": "Erwin pleads his case for the Scouts to be spared, but an unforeseen announcement puts the fate of humanity at risk.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-08-19T00:00:00Z",
+												"season": 3,
+												"number": 5,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/91d5d55b-9618-48f5-a1a8-1123e30f8d3b?base_image_bucket_name=image_manager&base_image=287b87aa-0163-4fe9-8197-8247d636b03a",
+														"hue": 0
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "07768f28-2e76-47fc-b086-beb5cb1791d1",
+												"href": null,
+												"eabId": "EAB::07768f28-2e76-47fc-b086-beb5cb1791d1::61170679::33160130",
+												"type": "episode",
+												"name": "(Sub) Reply",
+												"description": "Erwin pleads his case for the Scouts to be spared, but an unforeseen announcement puts the fate of humanity at risk.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-08-19T12:00:00Z",
+												"season": 3,
+												"number": 5,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/07768f28-2e76-47fc-b086-beb5cb1791d1?base_image_bucket_name=image_manager&base_image=61be4ba2-fa3b-4710-9e46-0103a033f4b4",
+														"hue": 0
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "e3d3ebc9-0c83-47d6-a25b-4be3468fe8a4",
+												"href": null,
+												"eabId": "EAB::e3d3ebc9-0c83-47d6-a25b-4be3468fe8a4::61694726::166829942",
+												"type": "episode",
+												"name": "(Dub) Declaration of War",
+												"description": "While Willy Tybur reveals the truth in a shocking speech to the world, tensions rise behind the stage as Eren and Reiner meet face to face.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-01-10T12:00:00Z",
+												"season": 4,
+												"number": 5,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/e3d3ebc9-0c83-47d6-a25b-4be3468fe8a4?base_image_bucket_name=image_manager&base_image=858b218c-d32a-4294-852a-8ca6ae8c2525",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "5aaca52f-a02c-4150-9135-caf5db72e49c",
+												"href": null,
+												"eabId": "EAB::5aaca52f-a02c-4150-9135-caf5db72e49c::61617562::121268852",
+												"type": "episode",
+												"name": "(Sub) Declaration of War",
+												"description": "While Willy Tybur reveals the truth in a shocking speech to the world, tensions rise behind the stage as Eren and Reiner meet face to face.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-01-10T12:00:00Z",
+												"season": 4,
+												"number": 5,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/5aaca52f-a02c-4150-9135-caf5db72e49c?base_image_bucket_name=image_manager&base_image=1a766c63-3398-4b9a-8691-114e9bda4b3f",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "22d5ee25-12d0-4b4e-83be-77feeb975387",
+												"href": null,
+												"eabId": "EAB::22d5ee25-12d0-4b4e-83be-77feeb975387::60870848::3146726",
+												"type": "episode",
+												"name": "(Dub) The World the Girl Saw / The Struggle for Trost: Part 2",
+												"description": "World the Girl Saw: The Struggle for Trost, Part 2, The: Armin tries to cope with the loss of his friends and allies after Titans massacre his squad. Elsewhere in the city, Mikasa manages to take out several of the monsters, which brings back tragic memories of her past and the first time she met Eren.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-05-12T00:00:00Z",
+												"season": 1,
+												"number": 6,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/22d5ee25-12d0-4b4e-83be-77feeb975387?base_image_bucket_name=image_manager&base_image=043e4da5-3859-4c06-87ef-c99d964c7443",
+														"hue": 205
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "7df0c5c1-38fe-456a-bbf6-cb2c456e5bf5",
+												"href": null,
+												"eabId": "EAB::7df0c5c1-38fe-456a-bbf6-cb2c456e5bf5::60218591::195962167",
+												"type": "episode",
+												"name": "(Sub) The World Seen by a Young Girl / Attack on Trost, Part 2",
+												"description": "Armin tries to cope with the loss of his friends and allies after Titans massacre his squad. Elsewhere in the city, Mikasa manages to take out several of the monsters, which brings back tragic memories of her past and the first time she met Eren.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-05-12T12:00:00Z",
+												"season": 1,
+												"number": 6,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/7df0c5c1-38fe-456a-bbf6-cb2c456e5bf5?base_image_bucket_name=image_manager&base_image=1789e201-8847-4f48-9067-5ddd9659110c",
+														"hue": 205
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "459eb94d-0e4c-4a7b-8e08-29752e4cf0fb",
+												"href": null,
+												"eabId": "EAB::459eb94d-0e4c-4a7b-8e08-29752e4cf0fb::61087262::23111356",
+												"type": "episode",
+												"name": "(Dub) Warrior",
+												"description": "Following the battle, the Scouts regroup atop the wall only to find more questions than answers. Before they leave for Trost to get medical attention, Reiner must fulfill what he came to do.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-05-06T07:00:00Z",
+												"season": 2,
+												"number": 6,
+												"duration": 1393,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/459eb94d-0e4c-4a7b-8e08-29752e4cf0fb?base_image_bucket_name=image_manager&base_image=e964ce83-2b1c-45af-99e4-557d3f204a77",
+														"hue": 205
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "94f49953-ae4e-41a1-8422-e3d12f44634d",
+												"href": null,
+												"eabId": "EAB::94f49953-ae4e-41a1-8422-e3d12f44634d::60885857::4253649",
+												"type": "episode",
+												"name": "(Sub) Warrior",
+												"description": "Following the battle, the Scouts regroup atop the wall only to find more questions than answers. Before they leave for Trost to get medical attention, Reiner must fulfill what he came to do.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-05-06T12:00:00Z",
+												"season": 2,
+												"number": 6,
+												"duration": 1473,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/94f49953-ae4e-41a1-8422-e3d12f44634d?base_image_bucket_name=image_manager&base_image=173e30c7-7e19-4935-9852-fe149d5a308c",
+														"hue": 205
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "3283ac61-4076-4860-bf37-07e541fffc20",
+												"href": null,
+												"eabId": "EAB::3283ac61-4076-4860-bf37-07e541fffc20::61383923::64515274",
+												"type": "episode",
+												"name": "(Dub) Sin",
+												"description": "While sins of the past reveal new truths, both sides prepare for the upcoming showdown before they run out of time.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-08-26T12:00:00Z",
+												"season": 3,
+												"number": 6,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/3283ac61-4076-4860-bf37-07e541fffc20?base_image_bucket_name=image_manager&base_image=9630ad62-bffc-40c2-a7a2-ece4d7679fb0",
+														"hue": 220
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "997a598c-7f23-47b1-9760-ea4e39596f6c",
+												"href": null,
+												"eabId": "EAB::997a598c-7f23-47b1-9760-ea4e39596f6c::61174675::33693268",
+												"type": "episode",
+												"name": "(Sub) Sin",
+												"description": "While sins of the past reveal new truths, both sides prepare for the upcoming showdown before they run out of time.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-08-26T12:00:00Z",
+												"season": 3,
+												"number": 6,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/997a598c-7f23-47b1-9760-ea4e39596f6c?base_image_bucket_name=image_manager&base_image=b653f6ab-04cc-49d2-8151-da406e83a463",
+														"hue": 220
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "761d3831-e798-47e8-aa41-723d2ca96e62",
+												"href": null,
+												"eabId": "EAB::761d3831-e798-47e8-aa41-723d2ca96e62::61694721::166829929",
+												"type": "episode",
+												"name": "(Dub) The War Hammer Titan",
+												"description": "Eren's rampage is thwarted by the War Hammer Titan whose tenacity leaves him stumped. With Marley's military joining the fight, he'll be hard-pressed to survive on his own.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-01-17T12:00:00Z",
+												"season": 4,
+												"number": 6,
+												"duration": 1435,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/761d3831-e798-47e8-aa41-723d2ca96e62?base_image_bucket_name=image_manager&base_image=c68b0841-c075-4975-8d37-6221182ac29a",
+														"hue": 60
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "c0af9713-f01b-4868-a7ad-b4db6efe0f66",
+												"href": null,
+												"eabId": "EAB::c0af9713-f01b-4868-a7ad-b4db6efe0f66::61619872::122018993",
+												"type": "episode",
+												"name": "(Sub) The War Hammer Titan",
+												"description": "Eren's rampage is thwarted by the War Hammer Titan whose tenacity leaves him stumped. With Marley's military joining the fight, he'll be hard-pressed to survive on his own.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-01-17T12:00:00Z",
+												"season": 4,
+												"number": 6,
+												"duration": 1457,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/c0af9713-f01b-4868-a7ad-b4db6efe0f66?base_image_bucket_name=image_manager&base_image=ad8e7b56-3717-44d9-a2be-44072c1ea024",
+														"hue": 60
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "67eeaf55-7e65-4b36-91f8-96c456852d41",
+												"href": null,
+												"eabId": "EAB::67eeaf55-7e65-4b36-91f8-96c456852d41::60870834::183890660",
+												"type": "episode",
+												"name": "(Dub) The Tiniest of Blades / Attack on Trost, Part 3",
+												"description": "After the retreat bell sounds, many cadets find themselves without enough fuel to scale the wall back to safety. Mikasa begins to lose hope once she hears of the deaths in Armin's squad.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-05-19T00:00:00Z",
+												"season": 1,
+												"number": 7,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/67eeaf55-7e65-4b36-91f8-96c456852d41?base_image_bucket_name=image_manager&base_image=939038e6-ffb5-4a33-b690-120355b7e1c7",
+														"hue": 60
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "63e8115f-299a-4b18-8ab2-154731e0b54e",
+												"href": null,
+												"eabId": "EAB::63e8115f-299a-4b18-8ab2-154731e0b54e::60218951::195956975",
+												"type": "episode",
+												"name": "(Sub) The Tiniest of Blades / Attack on Trost, Part 3",
+												"description": "After the retreat bell sounds, many cadets find themselves without enough fuel to scale the wall back to safety. Mikasa begins to lose hope once she hears of the deaths in Armin's squad, but the appearance of a new type of Titan stokes her will to fight.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-05-19T12:00:00Z",
+												"season": 1,
+												"number": 7,
+												"duration": 1450,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/63e8115f-299a-4b18-8ab2-154731e0b54e?base_image_bucket_name=image_manager&base_image=1f543cef-1f45-462c-a436-984872de9977",
+														"hue": 10
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "5c0b1d54-a066-44cb-ba8c-da4095dfa271",
+												"href": null,
+												"eabId": "EAB::5c0b1d54-a066-44cb-ba8c-da4095dfa271::61087261::23111315",
+												"type": "episode",
+												"name": "(Dub) Close Combat",
+												"description": "With a new enemy revealed, Eren and the Scouts fight back using all the techniques at their disposal. However, the Armored and Colossal Titan have other plans in mind.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-05-13T00:00:00Z",
+												"season": 2,
+												"number": 7,
+												"duration": 1393,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/5c0b1d54-a066-44cb-ba8c-da4095dfa271?base_image_bucket_name=image_manager&base_image=4ba559f0-c19b-4023-84de-9f278c373119",
+														"hue": 5
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "a67c0d15-7cc1-4c09-a964-c730bb42cba0",
+												"href": null,
+												"eabId": "EAB::a67c0d15-7cc1-4c09-a964-c730bb42cba0::60889664::4485783",
+												"type": "episode",
+												"name": "(Sub) Close Combat",
+												"description": "With a new enemy revealed, Eren and the Scouts fight back using all the techniques at their disposal. However, the Armored and Colossal Titan have other plans in mind.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-05-13T12:00:00Z",
+												"season": 2,
+												"number": 7,
+												"duration": 1473,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/a67c0d15-7cc1-4c09-a964-c730bb42cba0?base_image_bucket_name=image_manager&base_image=ed976ac3-9515-4946-ac58-f32919e77555",
+														"hue": 5
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "6ba6891e-be34-473c-9053-8d3a1666f18e",
+												"href": null,
+												"eabId": "EAB::6ba6891e-be34-473c-9053-8d3a1666f18e::61383946::64515070",
+												"type": "episode",
+												"name": "(Dub) Wish",
+												"description": "As battle breaks out to prevent the ritual, Historia makes a shocking decision which leads to catastrophe.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-09-02T00:00:00Z",
+												"season": 3,
+												"number": 7,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/6ba6891e-be34-473c-9053-8d3a1666f18e?base_image_bucket_name=image_manager&base_image=90d1daa1-6121-4577-9887-2412c68cbc41",
+														"hue": 210
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "97637a4f-dc5a-4440-9e68-721efdc27e0e",
+												"href": null,
+												"eabId": "EAB::97637a4f-dc5a-4440-9e68-721efdc27e0e::61179309::34235913",
+												"type": "episode",
+												"name": "(Sub) Wish",
+												"description": "As battle breaks out to prevent the ritual, Historia makes a shocking decision which leads to catastrophe.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-09-02T12:00:00Z",
+												"season": 3,
+												"number": 7,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/97637a4f-dc5a-4440-9e68-721efdc27e0e?base_image_bucket_name=image_manager&base_image=2ac194bc-e7c6-4092-8358-bde898ded2e0",
+														"hue": 210
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "b69a321c-1401-4fc9-8423-ae16512d9980",
+												"href": null,
+												"eabId": "EAB::b69a321c-1401-4fc9-8423-ae16512d9980::61694703::183883337",
+												"type": "episode",
+												"name": "(Dub) Assault",
+												"description": "The forces of Paradis begin their assault, but the Warriors stand their ground. As Marley troops close in around them, Eren struggles to break the War Hammer's defenses.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-01-24T12:00:00Z",
+												"season": 4,
+												"number": 7,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/b69a321c-1401-4fc9-8423-ae16512d9980?base_image_bucket_name=image_manager&base_image=8bd88695-fddc-4a0c-a688-81673f1103ac",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "00ac79f1-1446-4ba7-83ad-f7e815c0bebc",
+												"href": null,
+												"eabId": "EAB::00ac79f1-1446-4ba7-83ad-f7e815c0bebc::61621708::122778840",
+												"type": "episode",
+												"name": "(Sub) Assault",
+												"description": "The forces of Paradis begin their assault, but the Warriors stand their ground. As Marley troops close in around them, Eren struggles to break the War Hammer's defenses.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-01-24T12:00:00Z",
+												"season": 4,
+												"number": 7,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/00ac79f1-1446-4ba7-83ad-f7e815c0bebc?base_image_bucket_name=image_manager&base_image=23517a20-fb03-431e-8919-ffefbbd2cb15",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "b58ac30b-07e0-453d-bbcc-ea182566988c",
+												"href": null,
+												"eabId": "EAB::b58ac30b-07e0-453d-bbcc-ea182566988c::60870856::3132201",
+												"type": "episode",
+												"name": "(Dub) I Can Hear His Heartbeat: The Struggle for Trost, Part 4",
+												"description": "Armin comes up with a risky plan that pits Titan against Titan as the abandoned Cadets attempt to take back their headquarters. Getting into the building might be possible but getting out alive and refueled will mean facing more of the giants.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-05-26T00:00:00Z",
+												"season": 1,
+												"number": 8,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/b58ac30b-07e0-453d-bbcc-ea182566988c?base_image_bucket_name=image_manager&base_image=72df50ab-914e-4182-9fed-0ef7e92c96e3",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "2283b959-6544-4317-8a31-d409559249b7",
+												"href": null,
+												"eabId": "EAB::2283b959-6544-4317-8a31-d409559249b7::60222452::195962126",
+												"type": "episode",
+												"name": "(Sub) I Can Hear His Heartbeat: The Struggle for Trost, Part 4",
+												"description": "Armin comes up with a risky plan that pits Titan against Titan as the abandoned Cadets attempt to take back their headquarters. Getting into the building might be possible, but getting out alive and refueled will mean facing more of the giants.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-05-26T12:00:00Z",
+												"season": 1,
+												"number": 8,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/2283b959-6544-4317-8a31-d409559249b7?base_image_bucket_name=image_manager&base_image=63c7185d-1dd7-4f8d-9e2a-35be819dea2b",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "1e0407d2-26c9-4e2b-a5d8-01414b0e798f",
+												"href": null,
+												"eabId": "EAB::1e0407d2-26c9-4e2b-a5d8-01414b0e798f::61087268::23111354",
+												"type": "episode",
+												"name": "(Dub) The Hunters",
+												"description": "Without a way to pursue the Titans, the Scouts have no choice but to recuperate as they wait for reinforcements. But do they still have faith in Eren?",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-05-20T12:00:00Z",
+												"season": 2,
+												"number": 8,
+												"duration": 1393,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/1e0407d2-26c9-4e2b-a5d8-01414b0e798f?base_image_bucket_name=image_manager&base_image=0903db45-9e9f-4855-beee-f0bb7bd6f5ba",
+														"hue": 195
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "4e3016d2-d498-4973-afec-cd98de6e9ba1",
+												"href": null,
+												"eabId": "EAB::4e3016d2-d498-4973-afec-cd98de6e9ba1::60893758::4720842",
+												"type": "episode",
+												"name": "(Sub) The Hunters",
+												"description": "Without a way to pursue the Titans, the Scouts have no choice but to recuperate as they wait for reinforcements. But do they still have faith in Eren?",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-05-20T12:00:00Z",
+												"season": 2,
+												"number": 8,
+												"duration": 1473,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/4e3016d2-d498-4973-afec-cd98de6e9ba1?base_image_bucket_name=image_manager&base_image=f9a44a75-99c5-4dc6-bb5f-dd1ea371e923",
+														"hue": 195
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "a49de2dd-6c81-47a4-93ed-a8370af96519",
+												"href": null,
+												"eabId": "EAB::a49de2dd-6c81-47a4-93ed-a8370af96519::61383849::64428130",
+												"type": "episode",
+												"name": "(Dub) Outside the Walls of Orvud District",
+												"description": "Outside the Walls of Orvud District: When everything falls apart, Eren must believe in himself to save his friends. But, Eren alone may not be enough to stop the impending doom.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-09-09T00:00:00Z",
+												"season": 3,
+												"number": 8,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/a49de2dd-6c81-47a4-93ed-a8370af96519?base_image_bucket_name=image_manager&base_image=f3e5cea4-93c7-41b1-a7e8-791677300d36",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "e56a1614-8f15-4507-a84f-74bf3709d3e6",
+												"href": null,
+												"eabId": "EAB::e56a1614-8f15-4507-a84f-74bf3709d3e6::61183021::34885953",
+												"type": "episode",
+												"name": "(Sub) Outside the Walls of Orvud District",
+												"description": "When everything falls apart, Eren must believe in himself to save his friends. But Eren alone may not be enough to stop the impending doom.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-09-09T12:00:00Z",
+												"season": 3,
+												"number": 8,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/e56a1614-8f15-4507-a84f-74bf3709d3e6?base_image_bucket_name=image_manager&base_image=b2855bd4-22a3-486f-a7fc-1afbea8a19f9",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "81c209b9-6dea-4bc8-96b4-11e4a0faba4a",
+												"href": null,
+												"eabId": "EAB::81c209b9-6dea-4bc8-96b4-11e4a0faba4a::61694723::166829945",
+												"type": "episode",
+												"name": "(Dub) Assassin's Bullet",
+												"description": "With no Titans left to threaten their escape, the Scouts retreat on the airship. Determined to make them pay for trampling on her home, Gabi chases after with gun in hand.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-01-31T20:00:00Z",
+												"season": 4,
+												"number": 8,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/81c209b9-6dea-4bc8-96b4-11e4a0faba4a?base_image_bucket_name=image_manager&base_image=198449bf-3755-4438-b482-1b31b640033d",
+														"hue": 20
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "58126672-6037-4fc7-99f9-5180d5bb770b",
+												"href": null,
+												"eabId": "EAB::58126672-6037-4fc7-99f9-5180d5bb770b::61625005::123520580",
+												"type": "episode",
+												"name": "(Sub) Assassin's Bullet",
+												"description": "With no Titans left to threaten their escape, the Scouts retreat on the airship. Determined to make them pay for trampling on her home, Gabi chases after with gun in hand.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-01-31T12:00:00Z",
+												"season": 4,
+												"number": 8,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/58126672-6037-4fc7-99f9-5180d5bb770b?base_image_bucket_name=image_manager&base_image=769765a1-0613-466b-b505-b8483f9605b1",
+														"hue": 20
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "93e77951-abd4-4f14-8739-fc83a3c3c92d",
+												"href": null,
+												"eabId": "EAB::93e77951-abd4-4f14-8739-fc83a3c3c92d::60870851::183890667",
+												"type": "episode",
+												"name": "(Dub) What Happened to His Left Arm? / Attack On Trost Part 5",
+												"description": "Whereabouts of His Left Arm: The Struggle for Trost, Part 5: A miraculous return is met with anger and fear. Cannons are fixed on Eren as he struggles to remember what happened to him inside the belly of a monster.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-06-02T00:00:00Z",
+												"season": 1,
+												"number": 9,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/93e77951-abd4-4f14-8739-fc83a3c3c92d?base_image_bucket_name=image_manager&base_image=649293e8-6cb2-491c-aede-7f951bce274c",
+														"hue": 5
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "52460318-26b0-4301-8b10-0bc93edfe0c7",
+												"href": null,
+												"eabId": "EAB::52460318-26b0-4301-8b10-0bc93edfe0c7::60225168::195962133",
+												"type": "episode",
+												"name": "(Sub) What Happened to His Left Arm? / Attack On Trost Part 5",
+												"description": "A miraculous return is met with anger and fear. Cannons are fixed on Eren as he struggles to remember what happened to him inside the belly of a monster and how he ended up humankind's enemy. One question is all that matters: is Eren human or Titan?",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-06-02T12:00:00Z",
+												"season": 1,
+												"number": 9,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/52460318-26b0-4301-8b10-0bc93edfe0c7?base_image_bucket_name=image_manager&base_image=8b13eaf1-08b3-49ad-943b-0df4d77d9701",
+														"hue": 5
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "c893867e-57ca-4481-aa04-e3b520d46a49",
+												"href": null,
+												"eabId": "EAB::c893867e-57ca-4481-aa04-e3b520d46a49::61087269::32953560",
+												"type": "episode",
+												"name": "(Dub) Opening",
+												"description": "The Scouts rally and charge in pursuit, but Reiner is not quite himself while the group is trapped in the giant forest until nightfall.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-05-27T00:00:00Z",
+												"season": 2,
+												"number": 9,
+												"duration": 1393,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/c893867e-57ca-4481-aa04-e3b520d46a49?base_image_bucket_name=image_manager&base_image=653e0a65-8e6c-43c0-9bdf-6f19b5eec2ba",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "2a01299b-1903-4e1c-ae3a-1ccfdd844ae8",
+												"href": null,
+												"eabId": "EAB::2a01299b-1903-4e1c-ae3a-1ccfdd844ae8::60898992::4955475",
+												"type": "episode",
+												"name": "(Sub) Opening",
+												"description": "The Scouts rally and charge in pursuit, but Reiner is not quite himself while the group is trapped in the giant forest until nightfall.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-05-27T00:00:00Z",
+												"season": 2,
+												"number": 9,
+												"duration": 1473,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/2a01299b-1903-4e1c-ae3a-1ccfdd844ae8?base_image_bucket_name=image_manager&base_image=93015aa3-a8dc-4a14-a6bd-38d169a2bdbe",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "1a78b7f1-6a39-4c71-89d9-494e500cb53e",
+												"href": null,
+												"eabId": "EAB::1a78b7f1-6a39-4c71-89d9-494e500cb53e::61384253::64428157",
+												"type": "episode",
+												"name": "(Dub) Ruler of the Walls",
+												"description": "Desperate to stop the approaching monstrosity, the Scouts resort to unconventional tactics before it destroys everything in its path.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-09-16T12:00:00Z",
+												"season": 3,
+												"number": 9,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/1a78b7f1-6a39-4c71-89d9-494e500cb53e?base_image_bucket_name=image_manager&base_image=a7cf60ba-3d94-46db-a7de-fcbb1d249cee",
+														"hue": 215
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "9daabdd6-5bd2-474c-8419-667fa0526201",
+												"href": null,
+												"eabId": "EAB::9daabdd6-5bd2-474c-8419-667fa0526201::61186839::35469781",
+												"type": "episode",
+												"name": "(Sub) Ruler of the Walls",
+												"description": "Desperate to stop the approaching monstrosity, the Scouts resort to unconventional tactics before it destroys everything in its path.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-09-16T12:00:00Z",
+												"season": 3,
+												"number": 9,
+												"duration": 1461,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/9daabdd6-5bd2-474c-8419-667fa0526201?base_image_bucket_name=image_manager&base_image=5d0dd880-5ccb-4ef9-b0cd-b6218a53e101",
+														"hue": 215
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "480bec5c-cc8e-467f-bc45-7a668b37438a",
+												"href": null,
+												"eabId": "EAB::480bec5c-cc8e-467f-bc45-7a668b37438a::61694725::166829943",
+												"type": "episode",
+												"name": "(Dub) Brave Volunteers",
+												"description": "As Paradis deals with the aftermath of the raid on Liberio, Armin looks back into the past to meet the volunteer soldiers who reshaped their world.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-02-07T20:00:00Z",
+												"season": 4,
+												"number": 9,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/480bec5c-cc8e-467f-bc45-7a668b37438a?base_image_bucket_name=image_manager&base_image=7034038d-ea48-4e48-a01b-329c5eeb48b5",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "3607870f-d0ee-43b4-a960-2ab51b804503",
+												"href": null,
+												"eabId": "EAB::3607870f-d0ee-43b4-a960-2ab51b804503::61627490::124252467",
+												"type": "episode",
+												"name": "(Sub) Brave Volunteers",
+												"description": "As Paradis deals with the aftermath of the raid on Liberio, Armin looks back in the past to meeting the volunteer soldiers who reshaped their world.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-02-07T12:00:00Z",
+												"season": 4,
+												"number": 9,
+												"duration": 1457,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/3607870f-d0ee-43b4-a960-2ab51b804503?base_image_bucket_name=image_manager&base_image=94bb1e42-0793-442b-ab87-f63e486d250b",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "02eaf6c5-5cc9-412d-b763-7aaea3a12f85",
+												"href": null,
+												"eabId": "EAB::02eaf6c5-5cc9-412d-b763-7aaea3a12f85::60870852::183890653",
+												"type": "episode",
+												"name": "(Dub) Response: The Struggle for Trost Part 6",
+												"description": "Response: The Struggle for Trost Part 6: Cadets respond to Eren's terrifying transformation with doubt and fear as he struggles to understand it himself. If Armin can't talk the commander into using Eren's newfound powers for the good of humankind, all hope of stopping the Titans might be lost.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2014-07-12T00:00:00Z",
+												"season": 1,
+												"number": 10,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/02eaf6c5-5cc9-412d-b763-7aaea3a12f85?base_image_bucket_name=image_manager&base_image=b3fbabf5-dae1-4abd-8438-ea094c753163",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "0462e991-23b8-4401-87e5-c15b38302a5a",
+												"href": null,
+												"eabId": "EAB::0462e991-23b8-4401-87e5-c15b38302a5a::60227621::195962217",
+												"type": "episode",
+												"name": "(Sub) The Response / Attack on Trost, Part 6",
+												"description": "Cadets respond to Eren's terrifying transformation with doubt and fear as he struggles to understand it himself. If Armin can't talk the commander into using Eren's newfound powers for the good of humankind, all hope of stopping the Titans might be lost.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-06-09T12:00:00Z",
+												"season": 1,
+												"number": 10,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/0462e991-23b8-4401-87e5-c15b38302a5a?base_image_bucket_name=image_manager&base_image=e9e5de13-47ff-4d2d-8eee-b936e40211a8",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "aabf5d9c-5de9-4bfc-8e7c-6b443be2ff8a",
+												"href": null,
+												"eabId": "EAB::aabf5d9c-5de9-4bfc-8e7c-6b443be2ff8a::61087264::23111330",
+												"type": "episode",
+												"name": "(Dub) Children",
+												"description": "When their group finally flees, Ymir wonders whether she should lie or stay true to herself, even if it means ruining the lives and futures of those she cares about.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-06-03T00:00:00Z",
+												"season": 2,
+												"number": 10,
+												"duration": 1393,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/aabf5d9c-5de9-4bfc-8e7c-6b443be2ff8a?base_image_bucket_name=image_manager&base_image=9e14ec25-6e13-4012-9c34-82e3f35c32c8",
+														"hue": 20
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "a3e866b2-c2b2-4651-aaaa-5199cd818cd8",
+												"href": null,
+												"eabId": "EAB::a3e866b2-c2b2-4651-aaaa-5199cd818cd8::60902968::5230092",
+												"type": "episode",
+												"name": "(Sub) Children",
+												"description": "When their group finally flees, Ymir wonders whether she should lie or stay true to herself, even if it means ruining the lives and future of those she cares about.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-06-03T12:00:00Z",
+												"season": 2,
+												"number": 10,
+												"duration": 1473,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/a3e866b2-c2b2-4651-aaaa-5199cd818cd8?base_image_bucket_name=image_manager&base_image=9c9d5519-23ff-4d64-9168-c1a070c98936",
+														"hue": 20
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "7d615c94-a9a5-46e2-b032-68a749476bc9",
+												"href": null,
+												"eabId": "EAB::7d615c94-a9a5-46e2-b032-68a749476bc9::61384015::64276822",
+												"type": "episode",
+												"name": "(Dub) Friends",
+												"description": "Kenny recalls the life which has brought him to death's door, but he gets to decide whether to live on or not.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-09-23T12:00:00Z",
+												"season": 3,
+												"number": 10,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/7d615c94-a9a5-46e2-b032-68a749476bc9?base_image_bucket_name=image_manager&base_image=754eb950-52e0-4033-8619-bb4dcf5dd74f",
+														"hue": 225
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "bfa61784-ca0b-49f9-9448-cf86f8bddae0",
+												"href": null,
+												"eabId": "EAB::bfa61784-ca0b-49f9-9448-cf86f8bddae0::61190916::35999783",
+												"type": "episode",
+												"name": "(Sub) Friends",
+												"description": "Kenny recalls the life which has brought him to death's door, but he gets to decide whether to live on or not.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-09-23T12:00:00Z",
+												"season": 3,
+												"number": 10,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/bfa61784-ca0b-49f9-9448-cf86f8bddae0?base_image_bucket_name=image_manager&base_image=6310f740-b093-46d9-b5c9-d5806178e2c4",
+														"hue": 225
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "55c4e0ff-3e7d-4cc2-87a2-3d326bbf024e",
+												"href": null,
+												"eabId": "EAB::55c4e0ff-3e7d-4cc2-87a2-3d326bbf024e::61694722::166829947",
+												"type": "episode",
+												"name": "(Dub) A Sound Argument",
+												"description": "Two years ago, Paradis welcomed their first visitor, who was surprised to see one of its own; obtaining their help will be critical in a three-part plan to protect Paradis.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-02-14T20:00:00Z",
+												"season": 4,
+												"number": 10,
+												"duration": 1450,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/55c4e0ff-3e7d-4cc2-87a2-3d326bbf024e?base_image_bucket_name=image_manager&base_image=3414515e-60f9-4a21-9b4f-3ebcd401a3bd",
+														"hue": 25
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "7d5bfc56-3ab0-48a9-897f-26aa60ca0058",
+												"href": null,
+												"eabId": "EAB::7d5bfc56-3ab0-48a9-897f-26aa60ca0058::61630005::125000390",
+												"type": "episode",
+												"name": "(Sub) A Sound Argument",
+												"description": "Two years ago, Paradis welcomed their first visitor who was surprised to see one of their own. Obtaining their help will be critical in a three-part plan to protect Paradis.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-02-14T12:00:00Z",
+												"season": 4,
+												"number": 10,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/7d5bfc56-3ab0-48a9-897f-26aa60ca0058?base_image_bucket_name=image_manager&base_image=93ea05a5-c5ee-4164-97d8-b583a3a02487",
+														"hue": 25
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "4cfd224e-ee6a-4615-b0a2-04ca721411b1",
+												"href": null,
+												"eabId": "EAB::4cfd224e-ee6a-4615-b0a2-04ca721411b1::60870843::183890679",
+												"type": "episode",
+												"name": "(Dub) Idol / Attack On Trost, Part 7",
+												"description": "Plans are created to use Eren's Titan powers to seal the hole in the wall in an attempt reclaim Trost. But with the government's bloodstained history and vocal dissenters in the military ranks, the biggest threat to humankind may not be the Titans.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-06-16T00:00:00Z",
+												"season": 1,
+												"number": 11,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/4cfd224e-ee6a-4615-b0a2-04ca721411b1?base_image_bucket_name=image_manager&base_image=57047266-0615-4df1-97d3-daaeccc9fcb5",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "33ba487f-a418-4833-8dd7-ba1bd49fd37d",
+												"href": null,
+												"eabId": "EAB::33ba487f-a418-4833-8dd7-ba1bd49fd37d::60232095::195962212",
+												"type": "episode",
+												"name": "(Sub) Idol / Attack on Trost, Part 7",
+												"description": "Plans are created to use Eren's Titan powers to seal the hole in the wall in an attempt to reclaim Trost. But with the government's bloodstained history and vocal dissenters in the military ranks, the biggest threat to humankind may not be the Titans.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-06-16T12:00:00Z",
+												"season": 1,
+												"number": 11,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/33ba487f-a418-4833-8dd7-ba1bd49fd37d?base_image_bucket_name=image_manager&base_image=0084a636-84ed-417d-a73f-3986d064ec8e",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "d05dd904-e641-43b5-9d02-de52cb0edab3",
+												"href": null,
+												"eabId": "EAB::d05dd904-e641-43b5-9d02-de52cb0edab3::61087263::23111334",
+												"type": "episode",
+												"name": "(Dub) Charge",
+												"description": "While the recruits attempt to reason with Bertholdt, Commander Erwin charges forth in a desperate strategy to topple the Armored Titan.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-06-10T00:00:00Z",
+												"season": 2,
+												"number": 11,
+												"duration": 1393,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/d05dd904-e641-43b5-9d02-de52cb0edab3?base_image_bucket_name=image_manager&base_image=2e0e604a-27ee-443d-a0b2-9c06981795ad",
+														"hue": 10
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "78bb22ca-779b-4c5a-90cf-74c963fbfc43",
+												"href": null,
+												"eabId": "EAB::78bb22ca-779b-4c5a-90cf-74c963fbfc43::60907763::5438728",
+												"type": "episode",
+												"name": "(Sub) Charge",
+												"description": "While the recruits attempt to reason with Bertholdt, Commander Erwin charges forth in a desperate strategy to topple the Armored Titan.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-06-10T12:00:00Z",
+												"season": 2,
+												"number": 11,
+												"duration": 1473,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/78bb22ca-779b-4c5a-90cf-74c963fbfc43?base_image_bucket_name=image_manager&base_image=b8ebb1f6-422f-493f-a162-29b84d85297b",
+														"hue": 10
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "d68644ae-7e46-4252-a852-05d776c3e3db",
+												"href": null,
+												"eabId": "EAB::d68644ae-7e46-4252-a852-05d776c3e3db::61383983::64428178",
+												"type": "episode",
+												"name": "(Dub) Bystander",
+												"description": "Having seen a glimpse of his father's past, Eren attempts to track down a man who might shed some light on his father's secrets.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-10-07T00:00:00Z",
+												"season": 3,
+												"number": 11,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/d68644ae-7e46-4252-a852-05d776c3e3db?base_image_bucket_name=image_manager&base_image=c1edda8d-1af0-4479-96af-4e0cafd80be4",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "15484b3a-6b25-4f06-855f-77d728b29dcd",
+												"href": null,
+												"eabId": "EAB::15484b3a-6b25-4f06-855f-77d728b29dcd::61204259::37192828",
+												"type": "episode",
+												"name": "(Sub) Bystander",
+												"description": "Having seen a glimpse of his father's past, Eren attempts to track down a man who might shed some light on his father's secrets.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-10-07T12:00:00Z",
+												"season": 3,
+												"number": 11,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/15484b3a-6b25-4f06-855f-77d728b29dcd?base_image_bucket_name=image_manager&base_image=815cb771-560f-4044-9521-b582074b46b7",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "4356f5a9-6ccd-444c-8a25-2351a1e7e184",
+												"href": null,
+												"eabId": "EAB::4356f5a9-6ccd-444c-8a25-2351a1e7e184::61694713::166829970",
+												"type": "episode",
+												"name": "(Dub) Deceiver",
+												"description": "Trapped on the world's most dangerous island, Falco and Gabi will do anything to survive; elsewhere, the public demands answers when it learns the savior of Paradis has been detained.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-02-21T20:00:00Z",
+												"season": 4,
+												"number": 11,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/4356f5a9-6ccd-444c-8a25-2351a1e7e184?base_image_bucket_name=image_manager&base_image=daf6fc2b-adb1-4752-9c40-3f019e1c4ee3",
+														"hue": 30
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "09b59b12-ab28-4ce3-805b-886a748cdc9b",
+												"href": null,
+												"eabId": "EAB::09b59b12-ab28-4ce3-805b-886a748cdc9b::61632503::125741868",
+												"type": "episode",
+												"name": "(Sub) Deceiver",
+												"description": "Trapped on the world's most dangerous island, Falco and Gabi will do anything to survive. Elsewhere, the public demands answers when they learn the savior of Paradis has been detained.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-02-21T12:00:00Z",
+												"season": 4,
+												"number": 11,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/09b59b12-ab28-4ce3-805b-886a748cdc9b?base_image_bucket_name=image_manager&base_image=90bba203-5974-4ff6-b21d-ebf93c340d3b",
+														"hue": 30
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "11a13c66-0595-4a61-8271-efe63cbfa004",
+												"href": null,
+												"eabId": "EAB::11a13c66-0595-4a61-8271-efe63cbfa004::60870846::3146720",
+												"type": "episode",
+												"name": "(Dub) Flaw / Attack on Trost, Part 8",
+												"description": "The plan to reclaim Trost falls apart when Eren's newfound powers turn him into a mindless giant.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-06-23T00:00:00Z",
+												"season": 1,
+												"number": 12,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/11a13c66-0595-4a61-8271-efe63cbfa004?base_image_bucket_name=image_manager&base_image=bbce1391-62ca-46b7-94d0-a11230eeb566",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "42e60e31-5087-4d48-bd3d-697ff587dbae",
+												"href": null,
+												"eabId": "EAB::42e60e31-5087-4d48-bd3d-697ff587dbae::60233551::195962210",
+												"type": "episode",
+												"name": "(Sub) Flaw / Attack on Trost, Part 8",
+												"description": "The plan to reclaim Trost falls apart when Eren's newfound powers turn him into a mindless giant. As Titans continue to swarm the city, it's up to Armin and Mikasa to make sure the cadets massacred during the mission haven't died in vain.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-06-23T12:00:00Z",
+												"season": 1,
+												"number": 12,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/42e60e31-5087-4d48-bd3d-697ff587dbae?base_image_bucket_name=image_manager&base_image=7e7dfb1b-43c9-4903-b690-104836c42624",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "e249d1da-5f17-4894-986c-dbd3cd837a2c",
+												"href": null,
+												"eabId": "EAB::e249d1da-5f17-4894-986c-dbd3cd837a2c::61087270::183883029",
+												"type": "episode",
+												"name": "(Dub) Scream",
+												"description": "Eren's confrontation with a smiling Titan raises questions about his powers, but any answers will come at a cost.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-06-17T12:00:00Z",
+												"season": 2,
+												"number": 12,
+												"duration": 1363,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/e249d1da-5f17-4894-986c-dbd3cd837a2c?base_image_bucket_name=image_manager&base_image=f26ce929-d828-4cc3-97ea-e35566005a39",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "b78c36b1-901e-4be2-9099-b823521f6f6f",
+												"href": null,
+												"eabId": "EAB::b78c36b1-901e-4be2-9099-b823521f6f6f::60912237::5847945",
+												"type": "episode",
+												"name": "(Sub) Scream",
+												"description": "Eren's confrontation with a smiling Titan raises questions about his powers, but any answers will come at a cost.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2017-06-17T12:00:00Z",
+												"season": 2,
+												"number": 12,
+												"duration": 1443,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/b78c36b1-901e-4be2-9099-b823521f6f6f?base_image_bucket_name=image_manager&base_image=82865f55-b058-4acf-94a5-0ab94ad49a07",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "374f9331-f888-4ee4-9dc9-7dae8c216b61",
+												"href": null,
+												"eabId": "EAB::374f9331-f888-4ee4-9dc9-7dae8c216b61::61384002::64515149",
+												"type": "episode",
+												"name": "(Dub) Night of the Battle to Retake the Wall",
+												"description": "The Scouts enjoy a feast before retaking Wall Maria. They'll soon uncover what's hidden within the basement, once and for all.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-10-14T12:00:00Z",
+												"season": 3,
+												"number": 12,
+												"duration": 1445,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/374f9331-f888-4ee4-9dc9-7dae8c216b61?base_image_bucket_name=image_manager&base_image=853bf7bc-f0d7-40b5-a45f-ee6e4492404b",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "2cc5d63f-76aa-4e57-b77e-bc63ac7df069",
+												"href": null,
+												"eabId": "EAB::2cc5d63f-76aa-4e57-b77e-bc63ac7df069::61209321::37860994",
+												"type": "episode",
+												"name": "(Sub) Night of the Battle to Retake the Wall",
+												"description": "The Scouts enjoy a feast before retaking Wall Maria. They'll soon uncover what's hidden within the basement, once and for all.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2018-10-14T12:00:00Z",
+												"season": 3,
+												"number": 12,
+												"duration": 1442,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/2cc5d63f-76aa-4e57-b77e-bc63ac7df069?base_image_bucket_name=image_manager&base_image=c24acc6f-dcfb-4aa7-a403-2abd14db08eb",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "6116b488-93d1-4329-a117-886e6f0b9a04",
+												"href": null,
+												"eabId": "EAB::6116b488-93d1-4329-a117-886e6f0b9a04::61694701::166829967",
+												"type": "episode",
+												"name": "(Dub) Guides",
+												"description": "While Hange and Pyxis piece together Zeke's true intentions, tension builds outside HQ where Armin and Mikasa plead for permission to speak with Eren.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-02-28T12:00:00Z",
+												"season": 4,
+												"number": 12,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/6116b488-93d1-4329-a117-886e6f0b9a04?base_image_bucket_name=image_manager&base_image=c560ffeb-5187-4e9d-ad15-005a489d303b",
+														"hue": 25
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "295ede78-39d5-4ae1-9e24-51433f375d4f",
+												"href": null,
+												"eabId": "EAB::295ede78-39d5-4ae1-9e24-51433f375d4f::61635309::126517506",
+												"type": "episode",
+												"name": "(Sub) Guides",
+												"description": "While Hange and Pyxis piece together Zeke's true intentions, tension builds outside HQ where Armin and Mikasa plead for permission to speak with Eren.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-02-28T12:00:00Z",
+												"season": 4,
+												"number": 12,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/295ede78-39d5-4ae1-9e24-51433f375d4f?base_image_bucket_name=image_manager&base_image=c1e78d29-31c3-424f-a20e-948ca5accc6c",
+														"hue": 25
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "1d2f4893-c32c-4a11-b534-f3d818eb3288",
+												"href": null,
+												"eabId": "EAB::1d2f4893-c32c-4a11-b534-f3d818eb3288::60870840::3132195",
+												"type": "episode",
+												"name": "(Dub) Primal Desire / Attack on Trost Part 9",
+												"description": "Jean takes desperate measures to replace his broken maneuvering device. Meanwhile, Eren is able to plug the hole in the wall thanks to the help of his fellow cadets, but the cost of humanity's first victory against the Titans will be gigantic.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-06-30T23:30:00Z",
+												"season": 1,
+												"number": 13,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/1d2f4893-c32c-4a11-b534-f3d818eb3288?base_image_bucket_name=image_manager&base_image=12f06165-c2fd-4f2d-ab03-8b4a9950f228",
+														"hue": 0
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "0c96b145-9e49-4260-8d44-49d00b396c28",
+												"href": null,
+												"eabId": "EAB::0c96b145-9e49-4260-8d44-49d00b396c28::60236685::195962215",
+												"type": "episode",
+												"name": "(Sub) Primal Desire / Attack on Trost Part 9",
+												"description": "Jean takes desperate measures to replace his broken maneuvering device. Meanwhile, Eren is able to plug the hole in the wall thanks to the help of his fellow cadets, but the cost of humanity's first victory against the Titans will be gigantic.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-06-30T12:00:00Z",
+												"season": 1,
+												"number": 13,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/0c96b145-9e49-4260-8d44-49d00b396c28?base_image_bucket_name=image_manager&base_image=2d795da4-08f2-41ab-8bf0-a6e076acc967",
+														"hue": 0
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "516aa6de-c76c-4ed3-b934-cec2c6b9eb3a",
+												"href": null,
+												"eabId": "EAB::516aa6de-c76c-4ed3-b934-cec2c6b9eb3a::61504229::88773172",
+												"type": "episode",
+												"name": "(Dub) The Town Where Everything Began",
+												"description": "The operation to retake Wall Maria commences in Shiganshina, the town where everything began. But when the Scouts arrive, something seems very wrong.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-04-28T12:00:00Z",
+												"season": 3,
+												"number": 13,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/516aa6de-c76c-4ed3-b934-cec2c6b9eb3a?base_image_bucket_name=image_manager&base_image=8104ca2b-254d-41a9-913d-23e796a3ace1",
+														"hue": 200
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "91101490-a71d-4c90-80e8-9883055ee1ef",
+												"href": null,
+												"eabId": "EAB::91101490-a71d-4c90-80e8-9883055ee1ef::61338479::55787401",
+												"type": "episode",
+												"name": "(Sub) The Town Where Everything Began",
+												"description": "The operation to retake Wall Maria commences in Shiganshina, the town where everything began. But when the Scouts arrive, something seems very wrong.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-04-28T12:00:00Z",
+												"season": 3,
+												"number": 13,
+												"duration": 1464,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/91101490-a71d-4c90-80e8-9883055ee1ef?base_image_bucket_name=image_manager&base_image=19afb60a-d248-457b-98b3-efe06cb6ed14",
+														"hue": 200
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "e67cb30d-77d6-4e3d-ae32-e626238237d4",
+												"href": null,
+												"eabId": "EAB::e67cb30d-77d6-4e3d-ae32-e626238237d4::61694700::166829953",
+												"type": "episode",
+												"name": "(Dub) Children of the Forest",
+												"description": "Gabi and Falco seek out a fellow Marleyan who's surprised to see Warrior candidates. The truth of what happened at Ragako may shed some light on Zeke's secret plans.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-03-07T12:00:00Z",
+												"season": 4,
+												"number": 13,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/e67cb30d-77d6-4e3d-ae32-e626238237d4?base_image_bucket_name=image_manager&base_image=8451b5fd-ea0f-4c92-9296-a587d0b5527a",
+														"hue": 40
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "8b0275ab-645d-4f26-a0cc-00ec1aca507a",
+												"href": null,
+												"eabId": "EAB::8b0275ab-645d-4f26-a0cc-00ec1aca507a::61637680::127239118",
+												"type": "episode",
+												"name": "(Sub) Children of the Forest",
+												"description": "Gabi and Falco seek out a fellow Marleyan who's surprised to see Warrior candidates. The truth of what happened at Ragako may shed some light on Zeke's secret plans.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-03-07T12:00:00Z",
+												"season": 4,
+												"number": 13,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/8b0275ab-645d-4f26-a0cc-00ec1aca507a?base_image_bucket_name=image_manager&base_image=3426b09d-6852-4dae-a3b4-ba4b4fbbc1cb",
+														"hue": 40
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "4d90ea13-8f77-4a25-b062-2a95c8c40041",
+												"href": null,
+												"eabId": "EAB::4d90ea13-8f77-4a25-b062-2a95c8c40041::60870853::3146734",
+												"type": "episode",
+												"name": "(Dub) Still Can’t Look Him in the Eye / Eve of the Counteroffensive, Part 1",
+												"description": "A special military tribunal will decide Eren's fate. The Military Police calls for his execution while the Scout Regiment argues that he is a powerful resource for humankind, and Mikasa is put on the spot when asked about the events of the Trost mission.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-07-14T00:00:00Z",
+												"season": 1,
+												"number": 14,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/4d90ea13-8f77-4a25-b062-2a95c8c40041?base_image_bucket_name=image_manager&base_image=5b5d6c40-2fe9-40ec-8d3e-3f1902761776",
+														"hue": 185
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "567280d7-7def-44a1-90bc-08294aaf2291",
+												"href": null,
+												"eabId": "EAB::567280d7-7def-44a1-90bc-08294aaf2291::60242454::195962225",
+												"type": "episode",
+												"name": "(Sub) Still Can't Look Him in the Eye/Eve of the Counteroffensive, Part 1",
+												"description": "A special military tribunal will decide Eren's fate. The Military Police calls for his execution while the Scout Regiment argues that he is a powerful resource for humankind, and Mikasa is put on the spot when asked about the events of the Trost mission.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-07-14T12:00:00Z",
+												"season": 1,
+												"number": 14,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/567280d7-7def-44a1-90bc-08294aaf2291?base_image_bucket_name=image_manager&base_image=20fd884f-7d68-4e89-8f90-d266dc7c6626",
+														"hue": 185
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "a0050eb1-a788-4152-b193-12f63855c7a1",
+												"href": null,
+												"eabId": "EAB::a0050eb1-a788-4152-b193-12f63855c7a1::61504259::88773141",
+												"type": "episode",
+												"name": "(Dub) Thunder Spears",
+												"description": "Against a rush of enemies, the Scouts scramble to defend their horses. But despite falling into a trap, they have their own surprise for the Armored Titan.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-05-05T12:00:00Z",
+												"season": 3,
+												"number": 14,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/a0050eb1-a788-4152-b193-12f63855c7a1?base_image_bucket_name=image_manager&base_image=2f566fec-f1de-4541-bf89-d4ad023f93ca",
+														"hue": 200
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "b73dc1f7-116b-4b38-adae-f6e0fe133ab7",
+												"href": null,
+												"eabId": "EAB::b73dc1f7-116b-4b38-adae-f6e0fe133ab7::61343398::56461312",
+												"type": "episode",
+												"name": "(Sub) Thunder Spears",
+												"description": "Against a rush of enemies, the Scouts scramble to defend their horses. But despite falling into a trap, they have their own surprise for the Armored Titan.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-05-05T12:00:00Z",
+												"season": 3,
+												"number": 14,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/b73dc1f7-116b-4b38-adae-f6e0fe133ab7?base_image_bucket_name=image_manager&base_image=0e0a3fa0-f725-4b99-977f-fa43160a0d0a",
+														"hue": 200
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "6f09c00f-f9f5-4072-9d0b-069f21d64a11",
+												"href": null,
+												"eabId": "EAB::6f09c00f-f9f5-4072-9d0b-069f21d64a11::61694705::166829959",
+												"type": "episode",
+												"name": "(Dub) Savagery",
+												"description": "Armin and Mikasa speak with Eren, but are astounded by what he says. In the forest, Levi considers feeding the Beast Titan to someone new, but Zeke has other plans in mind.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-03-14T12:00:00Z",
+												"season": 4,
+												"number": 14,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/6f09c00f-f9f5-4072-9d0b-069f21d64a11?base_image_bucket_name=image_manager&base_image=6f15ff33-cfde-43cd-9e90-b8042c4159df",
+														"hue": 210
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "9f43a84c-1704-45e7-a30f-e9c069aa5e93",
+												"href": null,
+												"eabId": "EAB::9f43a84c-1704-45e7-a30f-e9c069aa5e93::61641566::128547321",
+												"type": "episode",
+												"name": "(Sub) Savagery",
+												"description": "Armin and Mikasa speak with Eren, but are astounded by what he says. In the forest, Levi considers feeding the Beast Titan to someone new, but Zeke has other plans in mind.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-03-14T21:00:00Z",
+												"season": 4,
+												"number": 14,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/9f43a84c-1704-45e7-a30f-e9c069aa5e93?base_image_bucket_name=image_manager&base_image=8489833b-510c-45bf-aa45-53868e9458a4",
+														"hue": 210
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "07078501-6126-41a4-913d-f10c90d6ac4c",
+												"href": null,
+												"eabId": "EAB::07078501-6126-41a4-913d-f10c90d6ac4c::60870832::3141867",
+												"type": "episode",
+												"name": "(Dub) Special Operations Squad: Eve of the Counterattack, Part 2",
+												"description": "The Scout Regiment moves Eren to an old abandoned castle where he will continue his training. Hanzi visits and reveals that she's been putting two captured Titans through a series of tests and trials-experiments that she wants Eren's help with.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-07-20T23:30:00Z",
+												"season": 1,
+												"number": 15,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/07078501-6126-41a4-913d-f10c90d6ac4c?base_image_bucket_name=image_manager&base_image=5b2081cf-0b73-442a-a2aa-e16e66e5f2c9",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "330c89ae-c9f1-489c-8cf4-f3ef2c38a8e7",
+												"href": null,
+												"eabId": "EAB::330c89ae-c9f1-489c-8cf4-f3ef2c38a8e7::60245829::195962228",
+												"type": "episode",
+												"name": "(Sub) Special Tactical Force/Eve of the Counteroffensive, Part 2",
+												"description": "The Scout Regiment moves Eren to an old abandoned castle where he will continue his training. Hanzi visits and reveals that she's been putting two captured Titans through a series of tests and trials - experiments that she wants Eren's help with.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-07-21T12:00:00Z",
+												"season": 1,
+												"number": 15,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/330c89ae-c9f1-489c-8cf4-f3ef2c38a8e7?base_image_bucket_name=image_manager&base_image=f4fe32e2-0436-4c17-aeae-8644b4b680ff",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "64bece63-f701-4880-bc49-4d7f90cfc0d8",
+												"href": null,
+												"eabId": "EAB::64bece63-f701-4880-bc49-4d7f90cfc0d8::61504285::88773159",
+												"type": "episode",
+												"name": "(Dub) Descent",
+												"description": "Though their Thunder Spears prove effective, the Scouts' celebration is short-lived as disaster descends upon Shiganshina.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-05-12T12:00:00Z",
+												"season": 3,
+												"number": 15,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/64bece63-f701-4880-bc49-4d7f90cfc0d8?base_image_bucket_name=image_manager&base_image=1ec6de95-5fb2-40eb-9604-efb990ddd14e",
+														"hue": 20
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "e2d325b6-b2e6-455f-b317-485c4f24c770",
+												"href": null,
+												"eabId": "EAB::e2d325b6-b2e6-455f-b317-485c4f24c770::61348531::57215862",
+												"type": "episode",
+												"name": "(Sub) Descent",
+												"description": "Though their Thunder Spears prove effective, the Scouts' celebration is short-lived as disaster descends upon Shiganshina.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-05-12T12:00:00Z",
+												"season": 3,
+												"number": 15,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/e2d325b6-b2e6-455f-b317-485c4f24c770?base_image_bucket_name=image_manager&base_image=20a44e3d-392c-411c-96f7-96811eadf08a",
+														"hue": 20
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "9efeafbd-7d17-4bc2-808e-d524b9199e8e",
+												"href": null,
+												"eabId": "EAB::9efeafbd-7d17-4bc2-808e-d524b9199e8e::61694689::166829935",
+												"type": "episode",
+												"name": "(Dub) Sole Salvation",
+												"description": "A look into Zeke's past shows his struggle to become a Warrior. His plans to end the suffering of all Eldians stems from a chance friendship made in his youth.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-03-21T12:00:00Z",
+												"season": 4,
+												"number": 15,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/9efeafbd-7d17-4bc2-808e-d524b9199e8e?base_image_bucket_name=image_manager&base_image=977069c2-0f4d-4e65-8301-c4e85760651e",
+														"hue": 220
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "3f1dbbce-fc1e-4072-a481-af6b6557a2e3",
+												"href": null,
+												"eabId": "EAB::3f1dbbce-fc1e-4072-a481-af6b6557a2e3::61641901::128664322",
+												"type": "episode",
+												"name": "(Sub) Sole Salvation",
+												"description": "A look into Zeke's past shows his struggle to become a Warrior. His plans to end the suffering of all Eldians stems from a chance friendship made in his youth.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-03-21T12:00:00Z",
+												"season": 4,
+												"number": 15,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/3f1dbbce-fc1e-4072-a481-af6b6557a2e3?base_image_bucket_name=image_manager&base_image=62d85a40-a749-485d-a984-4eedf4484700",
+														"hue": 220
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "0e385db0-48e5-4cf6-bb9a-c69a25560617",
+												"href": null,
+												"eabId": "EAB::0e385db0-48e5-4cf6-bb9a-c69a25560617::60870837::3146705",
+												"type": "episode",
+												"name": "(Dub) What Should I Do Now / Eve of the Counteroffensive, Part 3",
+												"description": "Everyone is a suspect in the investigation to find out who killed the two test-subject Titans. Meanwhile, the Cadets pick which corps they'll be joining, but after the harrowing events in the Trost attack, many are uncertain which branch to choose.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-07-28T00:00:00Z",
+												"season": 1,
+												"number": 16,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/0e385db0-48e5-4cf6-bb9a-c69a25560617?base_image_bucket_name=image_manager&base_image=431f61be-9a13-4608-8d93-298c5b7f1204",
+														"hue": 190
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "94398bbd-e3dd-40ed-971e-8b1a8cdc5d14",
+												"href": null,
+												"eabId": "EAB::94398bbd-e3dd-40ed-971e-8b1a8cdc5d14::60248693::195962234",
+												"type": "episode",
+												"name": "(Sub) What Should I Do Now / Eve of the Counteroffensive, Part 3",
+												"description": "Everyone is a suspect in the investigation to find out who killed the two test-subject Titans. Meanwhile, the Cadets pick which corps they'll be joining, but after the harrowing events in the Trost attack, many are uncertain which branch to choose.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-07-28T12:00:00Z",
+												"season": 1,
+												"number": 16,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/94398bbd-e3dd-40ed-971e-8b1a8cdc5d14?base_image_bucket_name=image_manager&base_image=f78355d3-2717-456e-8b04-9020cfab59cd",
+														"hue": 190
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "cd6f01b2-860b-4b11-abe9-0bd41232e53b",
+												"href": null,
+												"eabId": "EAB::cd6f01b2-860b-4b11-abe9-0bd41232e53b::61504357::88773186",
+												"type": "episode",
+												"name": "(Dub) Perfect Game",
+												"description": "While one front in the battle is rained on by flames, the other is battered by boulders. With no way out, the Scouts are forced to fight or die trying.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-05-19T12:00:00Z",
+												"season": 3,
+												"number": 16,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/cd6f01b2-860b-4b11-abe9-0bd41232e53b?base_image_bucket_name=image_manager&base_image=524c31ef-5665-4b5e-b98d-bfb43d2b4d38",
+														"hue": 200
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "d5517234-7faa-4db4-b837-92e627c7ca27",
+												"href": null,
+												"eabId": "EAB::d5517234-7faa-4db4-b837-92e627c7ca27::61353764::57961715",
+												"type": "episode",
+												"name": "(Sub) Perfect Game",
+												"description": "While one front in the battle is rained on by flames, the other is battered by boulders. With no way out, the Scouts are forced to fight or die trying.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-05-19T12:00:00Z",
+												"season": 3,
+												"number": 16,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/d5517234-7faa-4db4-b837-92e627c7ca27?base_image_bucket_name=image_manager&base_image=a9e2937b-9102-4134-a83a-b54e9b05841c",
+														"hue": 200
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "c4b92169-d51b-4b60-94d9-ddfee93b4b14",
+												"href": null,
+												"eabId": "EAB::c4b92169-d51b-4b60-94d9-ddfee93b4b14::61694714::166829956",
+												"type": "episode",
+												"name": "(Dub) Above and Below",
+												"description": "With the Jaegerists now in charge, Zeke's master plan is revealed. But before it is put in motion, Eren recruits help to flush out any invaders in their midst.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-03-28T12:00:00Z",
+												"season": 4,
+												"number": 16,
+												"duration": 1434,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/c4b92169-d51b-4b60-94d9-ddfee93b4b14?base_image_bucket_name=image_manager&base_image=e18a367e-50da-4c75-b1e3-fbc00d3e7831",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "fb4e4199-3257-436a-8f68-cc05bbfe19cf",
+												"href": null,
+												"eabId": "EAB::fb4e4199-3257-436a-8f68-cc05bbfe19cf::61643783::129431493",
+												"type": "episode",
+												"name": "(Sub) Above and Below",
+												"description": "With the Jaegerists now in charge, Zeke's master plan is revealed. But before it is put in motion, Eren recruits help to flush out any invaders in their midst.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2021-03-28T12:00:00Z",
+												"season": 4,
+												"number": 16,
+												"duration": 1443,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/fb4e4199-3257-436a-8f68-cc05bbfe19cf?base_image_bucket_name=image_manager&base_image=7fbe2928-8a92-48cf-9aef-9cbb9b87efc9",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "e3a97eff-0402-40eb-abbd-7fd0f80d692d",
+												"href": null,
+												"eabId": "EAB::e3a97eff-0402-40eb-abbd-7fd0f80d692d::60870841::3141875",
+												"type": "episode",
+												"name": "(Dub) Female Titan / The 57th Expedition, Part 1",
+												"description": "As the Scout Regiment begins its push toward Shiganshina, they encounter an intelligent Female Titan unlike any they've seen before. When Armin hypothesizes that it's really a human that's been turned into a Titan, he, Jean, and Reiner attempt to stop it.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-08-04T23:30:00Z",
+												"season": 1,
+												"number": 17,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/e3a97eff-0402-40eb-abbd-7fd0f80d692d?base_image_bucket_name=image_manager&base_image=37f7ad8b-5d84-4815-9ed1-53ef895b812a",
+														"hue": 55
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "269f76c5-bb50-486c-99fc-4ad913a98022",
+												"href": null,
+												"eabId": "EAB::269f76c5-bb50-486c-99fc-4ad913a98022::60251754::195962231",
+												"type": "episode",
+												"name": "(Sub) Female Titan / The 57th Expedition, Part 1",
+												"description": "As the Scout Regiment begins its push toward Shiganshina, they encounter an intelligent Female Titan unlike any they've seen before. When Armin hypothesizes that it's really a human that's been turned into a Titan, he, Jean, and Reiner attempt to stop it.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-08-04T00:00:00Z",
+												"season": 1,
+												"number": 17,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/269f76c5-bb50-486c-99fc-4ad913a98022?base_image_bucket_name=image_manager&base_image=fa6ef458-2a83-44b0-a91b-7f2860219d19",
+														"hue": 55
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "bed33ae3-0c1d-4d06-84ae-6d68655d7cef",
+												"href": null,
+												"eabId": "EAB::bed33ae3-0c1d-4d06-84ae-6d68655d7cef::61504325::88773156",
+												"type": "episode",
+												"name": "(Dub) Hero",
+												"description": "As Erwin's heroic charge buys Levi time to confront the Beast Titan, Armin comes up with a plan of his own that lays it all on the line.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-05-26T12:00:00Z",
+												"season": 3,
+												"number": 17,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/bed33ae3-0c1d-4d06-84ae-6d68655d7cef?base_image_bucket_name=image_manager&base_image=3b8a68cb-281f-4a31-bfb6-eeefed00d95e",
+														"hue": 200
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "736ffbbb-96f3-469c-99ea-53f8a824486f",
+												"href": null,
+												"eabId": "EAB::736ffbbb-96f3-469c-99ea-53f8a824486f::61360001::58814378",
+												"type": "episode",
+												"name": "(Sub) Hero",
+												"description": "As Erwin's heroic charge buys Levi time to confront the Beast Titan, Armin comes up with a plan of his own that lays it all on the line.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-05-26T12:00:00Z",
+												"season": 3,
+												"number": 17,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/736ffbbb-96f3-469c-99ea-53f8a824486f?base_image_bucket_name=image_manager&base_image=fb944436-4cba-4f1f-9c81-be1f929a7948",
+														"hue": 200
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "e0e5cd09-2d1b-48d2-a071-3588249d0f88",
+												"href": null,
+												"eabId": "EAB::e0e5cd09-2d1b-48d2-a071-3588249d0f88::61722365::227613862",
+												"type": "episode",
+												"name": "(Dub) Judgment",
+												"description": "Caught off guard by Marley's surprise attack, Eren fends off their Titans alone. As the battle rages on above, the Scouts consider Eren's motives from the underground dungeons.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-01-09T12:00:00Z",
+												"season": 4,
+												"number": 17,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/e0e5cd09-2d1b-48d2-a071-3588249d0f88?base_image_bucket_name=image_manager&base_image=d3963692-7967-4961-a0d0-76c964d4f14f",
+														"hue": 40
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "386f7bdd-4b2f-4c24-ae88-d758b50b6de4",
+												"href": null,
+												"eabId": "EAB::386f7bdd-4b2f-4c24-ae88-d758b50b6de4::61694153::162471068",
+												"type": "episode",
+												"name": "(Sub) Judgment",
+												"description": "Caught off guard by Marley's surprise attack, Eren fends off their Titans alone. As the battle rages on above, the Scouts consider Eren's motives from the underground dungeons.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-01-09T12:00:00Z",
+												"season": 4,
+												"number": 17,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/386f7bdd-4b2f-4c24-ae88-d758b50b6de4?base_image_bucket_name=image_manager&base_image=98ff6fe4-9292-462d-a347-8bd2a33dc8cc",
+														"hue": 40
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "802fe976-dca3-4ea7-9ba4-cb5410c082c4",
+												"href": null,
+												"eabId": "EAB::802fe976-dca3-4ea7-9ba4-cb5410c082c4::60870854::183890658",
+												"type": "episode",
+												"name": "(Dub) Forest of Giant Trees/The 57th Expedition, Part 2",
+												"description": "As the Female Titan continues to tear its way through the Scout Regiment, Levi makes a bold decision to split the ranks and send Eren and the supply wagons through a huge forest. Is his strategy genius, or does it spell certain death for the scouts?",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-08-11T00:00:00Z",
+												"season": 1,
+												"number": 18,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/802fe976-dca3-4ea7-9ba4-cb5410c082c4?base_image_bucket_name=image_manager&base_image=739c1cfe-2b8f-42c2-bef1-986004fd15da",
+														"hue": 195
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "7d28bc88-9748-49ac-a90a-5cef42545496",
+												"href": null,
+												"eabId": "EAB::7d28bc88-9748-49ac-a90a-5cef42545496::60254655::195962238",
+												"type": "episode",
+												"name": "(Sub) Forest of Giant Trees/The 57th Expedition, Part 2",
+												"description": "As the Female Titan continues to tear its way through the Scout Regiment, Levi makes a bold decision to split the ranks and send Eren and the supply wagons through a huge forest. Is his strategy genius, or does it spell certain death for the scouts?",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-08-11T12:00:00Z",
+												"season": 1,
+												"number": 18,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/7d28bc88-9748-49ac-a90a-5cef42545496?base_image_bucket_name=image_manager&base_image=d330680d-638e-4244-8cc3-29303ea4effe",
+														"hue": 195
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "6afd09ba-7215-415f-9324-bf116bec86b1",
+												"href": null,
+												"eabId": "EAB::6afd09ba-7215-415f-9324-bf116bec86b1::61504294::88773144",
+												"type": "episode",
+												"name": "(Dub) Midnight Sun",
+												"description": "While picking up the pieces from the costly battle, tensions rise when deciding which of the wounded Scouts to use the single syringe on.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-06-02T12:00:00Z",
+												"season": 3,
+												"number": 18,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/6afd09ba-7215-415f-9324-bf116bec86b1?base_image_bucket_name=image_manager&base_image=0a781534-11bd-4249-a12d-6e9df41f064a",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "f656f7da-f03f-4c9f-81ae-1fd5c2d0e660",
+												"href": null,
+												"eabId": "EAB::f656f7da-f03f-4c9f-81ae-1fd5c2d0e660::61364241::59592841",
+												"type": "episode",
+												"name": "(Sub) Midnight Sun",
+												"description": "While picking up the pieces from the costly battle, tensions rise when deciding which of the wounded Scouts to use the single syringe on.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-06-02T12:00:00Z",
+												"season": 3,
+												"number": 18,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/f656f7da-f03f-4c9f-81ae-1fd5c2d0e660?base_image_bucket_name=image_manager&base_image=54277c99-165c-40c6-8d45-7ddc8ef8a1bf",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "86bb4f0e-7f90-4306-b964-7ff44bc7c54b",
+												"href": null,
+												"eabId": "EAB::86bb4f0e-7f90-4306-b964-7ff44bc7c54b::61722371::227613836",
+												"type": "episode",
+												"name": "(Dub) Sneak Attack",
+												"description": "The Beast Titan joins the fray, but General Magath is determined to take him down. Meanwhile, with the city in flames, Colt and Gabi rush to rescue Falco who's held captive by the Jaegerists.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-01-16T12:00:00Z",
+												"season": 4,
+												"number": 18,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/86bb4f0e-7f90-4306-b964-7ff44bc7c54b?base_image_bucket_name=image_manager&base_image=e8cc6b89-2c2b-4d16-9954-73c2f1ea5be5",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "fa49d2c1-62ef-450a-a363-7bf81291b0ef",
+												"href": null,
+												"eabId": "EAB::fa49d2c1-62ef-450a-a363-7bf81291b0ef::61694754::163618496",
+												"type": "episode",
+												"name": "(Sub) Sneak Attack",
+												"description": "The Beast Titan joins the fray, but General Magath is determined to take him down. Meanwhile, with the city in flames, Colt and Gabi rush to rescue Falco who's held captive by the Jaegerists.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-01-16T16:00:00Z",
+												"season": 4,
+												"number": 18,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/fa49d2c1-62ef-450a-a363-7bf81291b0ef?base_image_bucket_name=image_manager&base_image=1f789ec0-cbe6-41f7-a237-a7a93e1dcbaa",
+														"hue": 30
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "5197000f-d950-4380-a05e-60b919edbf53",
+												"href": null,
+												"eabId": "EAB::5197000f-d950-4380-a05e-60b919edbf53::60870838::3141873",
+												"type": "episode",
+												"name": "(Dub) Bite/The 57th Expedition, Part 3\t",
+												"description": "The 57th Exterior Scouting Mission, Part 3: A memory of Eren testing out his Titan powers sheds new light on how his abilities work. As the Female Titan continues to slaughter members of the Scout Regiment, Eren is faced with a difficult decisions: does he trust his teammates or act out on his own?",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-08-18T12:00:00Z",
+												"season": 1,
+												"number": 19,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/5197000f-d950-4380-a05e-60b919edbf53?base_image_bucket_name=image_manager&base_image=f838c5d3-275d-4c14-aad9-9343bdd31016",
+														"hue": 25
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "b5d6b56a-2208-4045-a71a-7b42c24a59b7",
+												"href": null,
+												"eabId": "EAB::b5d6b56a-2208-4045-a71a-7b42c24a59b7::60257255::196053594",
+												"type": "episode",
+												"name": "(Sub) Bite/The 57th Expedition, Part 3",
+												"description": "A memory of Eren testing out his Titan powers sheds new light on how his abilities work. As the Female Titan continues to slaughter members of the Scout Regiment, Eren is faced with a difficult decisions: does he trust his teammates or act out on his own?",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-08-18T12:00:00Z",
+												"season": 1,
+												"number": 19,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/b5d6b56a-2208-4045-a71a-7b42c24a59b7?base_image_bucket_name=image_manager&base_image=fd56f271-9ef6-4c61-aab1-3c225aea392e",
+														"hue": 25
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "02a85533-5f55-4dfe-afa1-c4c5c1c7b6d5",
+												"href": null,
+												"eabId": "EAB::02a85533-5f55-4dfe-afa1-c4c5c1c7b6d5::61504340::88773153",
+												"type": "episode",
+												"name": "(Dub) The Basement",
+												"description": "The secrets hidden in Grisha's basement await in the ruins of Shiganshina. There, the Scouts hope to find answers to the world worth more than the price they paid.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-06-09T12:00:00Z",
+												"season": 3,
+												"number": 19,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/02a85533-5f55-4dfe-afa1-c4c5c1c7b6d5?base_image_bucket_name=image_manager&base_image=91297611-9c9c-43db-bf61-706abb3d62c8",
+														"hue": 215
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "7e35fe01-4561-4b66-b5c6-94d20e0b6685",
+												"href": null,
+												"eabId": "EAB::7e35fe01-4561-4b66-b5c6-94d20e0b6685::61367683::60217388",
+												"type": "episode",
+												"name": "(Sub) The Basement",
+												"description": "The secrets hidden in Grisha's basement await in the ruins of Shiganshina. There, the Scouts hope to find answers to the world worth more than the price they paid.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-06-09T12:00:00Z",
+												"season": 3,
+												"number": 19,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/7e35fe01-4561-4b66-b5c6-94d20e0b6685?base_image_bucket_name=image_manager&base_image=86526b81-cc01-4db5-a8ce-ac063cb2b9fc",
+														"hue": 215
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "990ebd07-84de-4ed6-adbe-37c137ed60d3",
+												"href": null,
+												"eabId": "EAB::990ebd07-84de-4ed6-adbe-37c137ed60d3::61722372::227613847",
+												"type": "episode",
+												"name": "(Dub) Two Brothers",
+												"description": "Colt pleads with Zeke to not use his scream and turn Falco into a Titan. All the while, soldiers and Titans clash in battle as Eren struggles to make contact with his brother.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-01-23T12:00:00Z",
+												"season": 4,
+												"number": 19,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/990ebd07-84de-4ed6-adbe-37c137ed60d3?base_image_bucket_name=image_manager&base_image=b0a170a4-9125-4e47-a99c-186fc1de2178",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "83ff5214-b5ed-423d-a127-c690549c2155",
+												"href": null,
+												"eabId": "EAB::83ff5214-b5ed-423d-a127-c690549c2155::61695301::164620007",
+												"type": "episode",
+												"name": "(Sub) Two Brothers",
+												"description": "Colt pleads with Zeke to not use his scream and turn Falco into a Titan. All the while, soldiers and Titans clash in battle as Eren struggles to make contact with his brother.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-01-23T12:00:00Z",
+												"season": 4,
+												"number": 19,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/83ff5214-b5ed-423d-a127-c690549c2155?base_image_bucket_name=image_manager&base_image=827a8554-fed2-4dbd-abff-efbf252aa16f",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "2c579969-e45d-4218-906a-47f29cd381e6",
+												"href": null,
+												"eabId": "EAB::2c579969-e45d-4218-906a-47f29cd381e6::60870833::3141870",
+												"type": "episode",
+												"name": "(Dub) Erwin Smith/The 57th Expedition, Part 4",
+												"description": "Erwin Smith: The 57th Exterior Scouting Mission, Part 4: The Female Titan has been captured, and it's Erwin's goal to find out who the human is lurking inside it. Meanwhile, the Scouts realize that the reason Levi told no one about their true mission outside the wall is because there is a spy among their ranks.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-08-25T23:30:00Z",
+												"season": 1,
+												"number": 20,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/2c579969-e45d-4218-906a-47f29cd381e6?base_image_bucket_name=image_manager&base_image=cffcc158-d5c6-4f62-8a07-1d4c99a12641",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "f4409c5b-7487-4b6a-88ae-3b2ebe1026cf",
+												"href": null,
+												"eabId": "EAB::f4409c5b-7487-4b6a-88ae-3b2ebe1026cf::60261162::196053597",
+												"type": "episode",
+												"name": "(Sub) Erwin Smith/The 57th Expedition, Part 4",
+												"description": "The Female Titan has been captured, and it's Erwin's goal to find out who the human is lurking inside it. Meanwhile, the Scouts realize that the reason Levi told no one about their true mission outside the wall is because there is a spy among them.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-08-25T12:00:00Z",
+												"season": 1,
+												"number": 20,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/f4409c5b-7487-4b6a-88ae-3b2ebe1026cf?base_image_bucket_name=image_manager&base_image=07af8e33-905a-4bda-9a94-f676e0c2ea96",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "3c679eb0-41ce-45eb-854f-a10ba5fd9953",
+												"href": null,
+												"eabId": "EAB::3c679eb0-41ce-45eb-854f-a10ba5fd9953::61504307::88773175",
+												"type": "episode",
+												"name": "(Dub) That Day",
+												"description": "A look into Grisha's memories shows Eren the many secrets his father was hiding, including one which led to his mother's demise.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-06-16T12:00:00Z",
+												"season": 3,
+												"number": 20,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/3c679eb0-41ce-45eb-854f-a10ba5fd9953?base_image_bucket_name=image_manager&base_image=a04efd33-0998-45da-b673-8c168d99503f",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "c238900a-e314-442f-87f7-5aa0f0d1ab02",
+												"href": null,
+												"eabId": "EAB::c238900a-e314-442f-87f7-5aa0f0d1ab02::61371564::60952738",
+												"type": "episode",
+												"name": "(Sub) That Day",
+												"description": "A look into Grisha's memories shows Eren the many secrets his father was hiding, including one which led to his mother's demise.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-06-16T12:00:00Z",
+												"season": 3,
+												"number": 20,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/c238900a-e314-442f-87f7-5aa0f0d1ab02?base_image_bucket_name=image_manager&base_image=dc04e52e-8f6a-49b7-8c32-1c4f6b3708fe",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "1f3e5a35-f6b3-4b05-8655-8f4f802c143c",
+												"href": null,
+												"eabId": "EAB::1f3e5a35-f6b3-4b05-8655-8f4f802c143c::61722367::227613865",
+												"type": "episode",
+												"name": "(Dub) Memories of the Future",
+												"description": "Zeke takes Eren through Grisha's memories to show him how he's been brainwashed. But in doing so, Zeke discovers something about Eren that he never knew.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-01-30T12:00:00Z",
+												"season": 4,
+												"number": 20,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/1f3e5a35-f6b3-4b05-8655-8f4f802c143c?base_image_bucket_name=image_manager&base_image=21c8b33c-4c3e-4286-a943-6a47bdd5d80d",
+														"hue": 45
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "0dd0e04d-8c34-41ec-9d08-177f125f47e3",
+												"href": null,
+												"eabId": "EAB::0dd0e04d-8c34-41ec-9d08-177f125f47e3::61695953::165703844",
+												"type": "episode",
+												"name": "(Sub) Memories of the Future",
+												"description": "Zeke takes Eren through Grisha's memories to show him how he's been brainwashed. But in doing so, Zeke discovers something about Eren that he never knew.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-01-30T12:00:00Z",
+												"season": 4,
+												"number": 20,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/0dd0e04d-8c34-41ec-9d08-177f125f47e3?base_image_bucket_name=image_manager&base_image=7010b6e6-af04-434d-99e3-6e10b1aec03d",
+														"hue": 45
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "50465121-2ef6-4964-88bb-35314853791e",
+												"href": null,
+												"eabId": "EAB::50465121-2ef6-4964-88bb-35314853791e::60870842::183890688",
+												"type": "episode",
+												"name": "(Dub) Iron Hammer/The 57th Expedition, Part 5",
+												"description": "The 57th Exterior Scouting Mission, Part 5: A traitor has infiltrated the Scout Regiment, destroying their ranks from within.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-09-01T23:30:00Z",
+												"season": 1,
+												"number": 21,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/50465121-2ef6-4964-88bb-35314853791e?base_image_bucket_name=image_manager&base_image=f95e4cbc-9202-452b-9f3f-bd75a0db78a7",
+														"hue": 350
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "eb47773b-b290-42cf-97d5-ff69d0eb6638",
+												"href": null,
+												"eabId": "EAB::eb47773b-b290-42cf-97d5-ff69d0eb6638::60263204::195962282",
+												"type": "episode",
+												"name": "(Sub) Iron Hammer/The 57th Expedition, Part 5",
+												"description": "A traitor has infiltrated the Scout Regiment, destroying their ranks from within. When cornered, she once again takes the form of the Female Titan - but this time, Eren's not going to let her get away without one insanely brutal fight.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-09-01T12:00:00Z",
+												"season": 1,
+												"number": 21,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/eb47773b-b290-42cf-97d5-ff69d0eb6638?base_image_bucket_name=image_manager&base_image=537026af-da78-4d30-b28e-be16e1f9cc7f",
+														"hue": 350
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "e3bc7c7c-3eb4-4603-b1e5-2a74458d81d8",
+												"href": null,
+												"eabId": "EAB::e3bc7c7c-3eb4-4603-b1e5-2a74458d81d8::61504277::88355296",
+												"type": "episode",
+												"name": "(Dub) Attack Titan",
+												"description": "Eren learns how all paths connect in the story that his father began. If Grisha is to pay for his sins, he must fight for freedom and take a stand.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-06-23T12:00:00Z",
+												"season": 3,
+												"number": 21,
+												"duration": 1460,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/e3bc7c7c-3eb4-4603-b1e5-2a74458d81d8?base_image_bucket_name=image_manager&base_image=98ab4a8b-21a7-4caa-8f00-bd165bc55512",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "3bc7f41e-0968-4d52-aedd-35a8b6573d4a",
+												"href": null,
+												"eabId": "EAB::3bc7f41e-0968-4d52-aedd-35a8b6573d4a::61375067::61643658",
+												"type": "episode",
+												"name": "(Sub) Attack Titan",
+												"description": "Eren learns how all paths connect in the story that his father began. If Grisha is to pay for his sins, he must fight for freedom and take a stand.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-06-23T12:00:00Z",
+												"season": 3,
+												"number": 21,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/3bc7f41e-0968-4d52-aedd-35a8b6573d4a?base_image_bucket_name=image_manager&base_image=5db46590-717a-4bbf-9cbe-a17155e85b25",
+														"hue": 35
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "1834c674-1ac0-48e8-aef0-7fe2f7b2af49",
+												"href": null,
+												"eabId": "EAB::1834c674-1ac0-48e8-aef0-7fe2f7b2af49::61722366::227613856",
+												"type": "episode",
+												"name": "(Dub) From You, 2,000 Years Ago",
+												"description": "For 2,000 years, the Founder Ymir has been waiting--a slave to those with royal blood. However, Eren's yearning for freedom gives her a choice that could shake things up.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2020-02-08T12:00:00Z",
+												"season": 4,
+												"number": 21,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/1834c674-1ac0-48e8-aef0-7fe2f7b2af49?base_image_bucket_name=image_manager&base_image=d33abf69-d1ce-4ace-8071-363f68721557",
+														"hue": 45
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "f0774a01-5641-4e6c-8075-ba8c7e49ea98",
+												"href": null,
+												"eabId": "EAB::f0774a01-5641-4e6c-8075-ba8c7e49ea98::61696419::166643184",
+												"type": "episode",
+												"name": "(Sub) From You, 2,000 Years Ago",
+												"description": "For 2,000 years, the Founder Ymir has been waiting--a slave to those with royal blood. However, Eren's yearning for freedom gives her a choice that could shake things up.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-02-06T12:00:00Z",
+												"season": 4,
+												"number": 21,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/f0774a01-5641-4e6c-8075-ba8c7e49ea98?base_image_bucket_name=image_manager&base_image=133e7b38-885b-4d6b-9879-6a8118f05a90",
+														"hue": 45
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "69fc6b9d-9177-42a7-82aa-96b43d34b2c3",
+												"href": null,
+												"eabId": "EAB::69fc6b9d-9177-42a7-82aa-96b43d34b2c3::60870836::183890654",
+												"type": "episode",
+												"name": "(Dub) The Defeated: The 57th Exterior Scouting Mission, Part 6",
+												"description": "After watching Eren get swallowed by the Female Titan, Mikasa and Levi follow the brutal monster in the hopes that he's still alive inside her. As the Scout Regiment tries to recover from the devastating losses of the operation, emotions run high.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-09-08T00:00:00Z",
+												"season": 1,
+												"number": 22,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/69fc6b9d-9177-42a7-82aa-96b43d34b2c3?base_image_bucket_name=image_manager&base_image=c47b8423-d703-48d9-8ab6-8557dc2a1b76",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "7100a4f0-0049-4129-acf6-28a215d5f1b8",
+												"href": null,
+												"eabId": "EAB::7100a4f0-0049-4129-acf6-28a215d5f1b8::60266367::196061146",
+												"type": "episode",
+												"name": "(Sub) The Defeated: The 57th Exterior Scouting Mission, Part 6",
+												"description": "After watching Eren get swallowed by the Female Titan, Mikasa and Levi follow the brutal monster in the hopes that he's still alive inside her. As the Scout Regiment tries to recover from the devastating losses of the operation, emotions run high.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-09-08T00:00:00Z",
+												"season": 1,
+												"number": 22,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/7100a4f0-0049-4129-acf6-28a215d5f1b8?base_image_bucket_name=image_manager&base_image=9d5847e9-6eda-45b5-9a2e-dfbaf9972ea2",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "ef0fe05a-d7e7-4ca8-922e-cd52e052ab9b",
+												"href": null,
+												"eabId": "EAB::ef0fe05a-d7e7-4ca8-922e-cd52e052ab9b::61504302::88773682",
+												"type": "episode",
+												"name": "(Dub) The Other Side of the Wall",
+												"description": "Though it's met with hope and despair, the truth is made public. The Scouts then venture beyond the walls to see if it's everything they dreamed of.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-06-30T12:00:00Z",
+												"season": 3,
+												"number": 22,
+												"duration": 1445,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/ef0fe05a-d7e7-4ca8-922e-cd52e052ab9b?base_image_bucket_name=image_manager&base_image=d33788a1-768b-46d3-a8be-dd126671c346",
+														"hue": 220
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "ff8a99bc-0b27-4f97-9286-56eed0cbc1fe",
+												"href": null,
+												"eabId": "EAB::ff8a99bc-0b27-4f97-9286-56eed0cbc1fe::61379033::62333868",
+												"type": "episode",
+												"name": "(Sub) The Other Side of the Wall",
+												"description": "Though it's met with hope and despair, the truth is made public. The Scouts then venture beyond the walls to see if it's everything they dreamed of.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2019-06-30T12:00:00Z",
+												"season": 3,
+												"number": 22,
+												"duration": 1443,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/ff8a99bc-0b27-4f97-9286-56eed0cbc1fe?base_image_bucket_name=image_manager&base_image=5de901ea-c522-4a60-ae43-9c3d15d39b3d",
+														"hue": 220
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "5e07dc7e-fff8-4a8a-83f0-c9f7e391e505",
+												"href": null,
+												"eabId": "EAB::5e07dc7e-fff8-4a8a-83f0-c9f7e391e505::61722373::227613845",
+												"type": "episode",
+												"name": "(Dub) Thaw",
+												"description": "With no walls left on the island and Shiganshina full of Titans, the Scouts must battle their former comrades. In the midst of it all, Gabi is determined to find and rescue Falco at whatever cost.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-02-15T12:00:00Z",
+												"season": 4,
+												"number": 22,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/5e07dc7e-fff8-4a8a-83f0-c9f7e391e505?base_image_bucket_name=image_manager&base_image=51c36557-438c-4b7d-bbbd-1ae98d1d4207",
+														"hue": 25
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "fbbe3381-8992-4724-8df2-723360e7ac7e",
+												"href": null,
+												"eabId": "EAB::fbbe3381-8992-4724-8df2-723360e7ac7e::61696853::167628762",
+												"type": "episode",
+												"name": "(Sub) Thaw",
+												"description": "With no walls left on the island and Shiganshina full of Titans, the Scouts must battle their former comrades. In the midst of it all, Gabi is determined to find and rescue Falco at whatever cost.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-02-13T12:00:00Z",
+												"season": 4,
+												"number": 22,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/fbbe3381-8992-4724-8df2-723360e7ac7e?base_image_bucket_name=image_manager&base_image=61f0955b-d2e9-41d4-bc9d-f3f8b580a8b1",
+														"hue": 25
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "5dd6f34d-85f7-44ac-beab-7e5dfc6e449b",
+												"href": null,
+												"eabId": "EAB::5dd6f34d-85f7-44ac-beab-7e5dfc6e449b::60870847::183890759",
+												"type": "episode",
+												"name": "(Dub) Smile/Stohess District Raid, Part 1",
+												"description": "After the failed scouting expedition, Eren and his superiors are summoned to the capital. Annie witnesses just how deep corruption runs in the Military Police, and agrees to join Armin in a plot to defy the government - but nothing is really as it seems.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-09-15T23:30:00Z",
+												"season": 1,
+												"number": 23,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/5dd6f34d-85f7-44ac-beab-7e5dfc6e449b?base_image_bucket_name=image_manager&base_image=019fc29d-b13f-4ed7-a6eb-a9962806cd82",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "73753f21-dd2d-427f-b708-e4272a12dec2",
+												"href": null,
+												"eabId": "EAB::73753f21-dd2d-427f-b708-e4272a12dec2::60269257::196053622",
+												"type": "episode",
+												"name": "(Sub) Smile/Stohess District Raid, Part 1",
+												"description": "After the failed scouting expedition, Eren and his superiors are summoned to the capital. Annie witnesses just how deep corruption runs in the Military Police, and agrees to join Armin in a plot to defy the government - but nothing is really as it seems.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-09-15T12:00:00Z",
+												"season": 1,
+												"number": 23,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/73753f21-dd2d-427f-b708-e4272a12dec2?base_image_bucket_name=image_manager&base_image=95663098-d95b-44cf-9557-3953fb96a7b9",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "feefc9e0-d5b9-4c33-be42-af78e6a7e575",
+												"href": null,
+												"eabId": "EAB::feefc9e0-d5b9-4c33-be42-af78e6a7e575::61722370::227613848",
+												"type": "episode",
+												"name": "(Dub) Sunset",
+												"description": "The rumbling is set in motion once all hardening is undone, but this also sets Annie free. As the Jaegerists take control of the island, Conny races towards Ragako to feed Falco to his Titan mother.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-02-22T12:00:00Z",
+												"season": 4,
+												"number": 23,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/feefc9e0-d5b9-4c33-be42-af78e6a7e575?base_image_bucket_name=image_manager&base_image=8bfc644e-69e5-404e-b835-c943b0ebba2b",
+														"hue": 230
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "20f996bb-adf5-4288-ae51-615c4080296e",
+												"href": null,
+												"eabId": "EAB::20f996bb-adf5-4288-ae51-615c4080296e::61697499::168642431",
+												"type": "episode",
+												"name": "(Sub) Sunset",
+												"description": "The rumbling is set in motion once all hardening is undone, but this also sets Annie free. As the Jaegerists take control of the island, Conny races towards Ragako to feed Falco to his Titan mother.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-02-20T12:00:00Z",
+												"season": 4,
+												"number": 23,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/20f996bb-adf5-4288-ae51-615c4080296e?base_image_bucket_name=image_manager&base_image=488ceb79-08d4-45df-866e-65cd481b36e8",
+														"hue": 230
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "5229f97b-63be-4f75-8832-2ce9379beac1",
+												"href": null,
+												"eabId": "EAB::5229f97b-63be-4f75-8832-2ce9379beac1::60870855::183890670",
+												"type": "episode",
+												"name": "(Dub) Compassion/Stohess District Raid, Part 2",
+												"description": "When the identity of the Female Titan is finally revealed, she goes on a rampage within Wall Sina. Eren is hesitant to fight her, but Armin and Mikasa throw themselves into of the battle in a desperate attempt to stop the towering monster.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-09-22T23:30:00Z",
+												"season": 1,
+												"number": 24,
+												"duration": 1468,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/5229f97b-63be-4f75-8832-2ce9379beac1?base_image_bucket_name=image_manager&base_image=1760958f-93b8-4591-8368-87439ca2195d",
+														"hue": 235
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "2948b1de-dbcd-4c0c-a5a7-b080756d73e2",
+												"href": null,
+												"eabId": "EAB::2948b1de-dbcd-4c0c-a5a7-b080756d73e2::60272657::196053600",
+												"type": "episode",
+												"name": "(Sub) Compassion / Stohess District Raid, Part 2",
+												"description": "When the identity of the Female Titan is finally revealed, she goes on a rampage within Wall Sina. Eren is hesitant to fight her, but Armin and Mikasa throw themselves into of the battle in a desperate attempt to stop the towering monster.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-09-22T00:00:00Z",
+												"season": 1,
+												"number": 24,
+												"duration": 1459,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/2948b1de-dbcd-4c0c-a5a7-b080756d73e2?base_image_bucket_name=image_manager&base_image=955f2c07-47fa-45e4-b344-84653d438df6",
+														"hue": 235
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "46a18bd7-9e32-4870-926c-c7e50600054b",
+												"href": null,
+												"eabId": "EAB::46a18bd7-9e32-4870-926c-c7e50600054b::61722361::227613850",
+												"type": "episode",
+												"name": "(Dub) Pride",
+												"description": "Upon reaching Ragako, Conny hatches a plan to trick Falco into being eaten by his mother. Elsewhere, hero of the Eldian Empire, Jean, is to execute Yelena and Onyankopon for their crimes against humanity.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-02-27T12:00:00Z",
+												"season": 4,
+												"number": 24,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/46a18bd7-9e32-4870-926c-c7e50600054b?base_image_bucket_name=image_manager&base_image=ced91fbd-b409-47d9-8abe-831af6a782a9",
+														"hue": 25
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "95ad7626-ba80-4c33-be23-9bfa51bb9754",
+												"href": null,
+												"eabId": "EAB::95ad7626-ba80-4c33-be23-9bfa51bb9754::61698186::169732003",
+												"type": "episode",
+												"name": "(Sub) Pride",
+												"description": "Upon reaching Ragako, Conny hatches a plan to trick Falco into being eaten by his mother. Elsewhere, hero of the Eldian Empire, Jean, is to execute Yelena and Onyankopon for their crimes against humanity.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-02-27T12:00:00Z",
+												"season": 4,
+												"number": 24,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/95ad7626-ba80-4c33-be23-9bfa51bb9754?base_image_bucket_name=image_manager&base_image=02509f4f-98ca-4c24-8c4d-bdf7122be75f",
+														"hue": 25
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "d5e31578-c75f-4256-9192-80cfe8f33fb5",
+												"href": null,
+												"eabId": "EAB::d5e31578-c75f-4256-9192-80cfe8f33fb5::60870839::183890677",
+												"type": "episode",
+												"name": "(Dub) Wall: Assault on Stohess, Part 3",
+												"description": "Eren goes head-to-head with the Female Titan in a fight that demolishes the Stohess District inside Wall Sina. As the casualties skyrocket and Annie tries to escape over the wall, Erwin must deal with the consequences of his plan.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2014-11-01T12:00:00Z",
+												"season": 1,
+												"number": 25,
+												"duration": 1453,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/d5e31578-c75f-4256-9192-80cfe8f33fb5?base_image_bucket_name=image_manager&base_image=d8d1f2b9-d210-4007-93fb-fd23a6a88891",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "6d5b2a65-2bd7-4d87-8c07-c239bbcbd4f8",
+												"href": null,
+												"eabId": "EAB::6d5b2a65-2bd7-4d87-8c07-c239bbcbd4f8::60276323::196053678",
+												"type": "episode",
+												"name": "(Sub) The Wall/Stohess District Raid, Part 3",
+												"description": "Eren goes head-to-head with the Female Titan in a fight that demolishes the Stohess District inside Wall Sina. As the number of casualties skyrockets and Annie tries to escape over the wall, Erwin must deal with the consequences of his plan.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-09-29T12:00:00Z",
+												"season": 1,
+												"number": 25,
+												"duration": 1444,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/6d5b2a65-2bd7-4d87-8c07-c239bbcbd4f8?base_image_bucket_name=image_manager&base_image=c5cea122-acac-46b1-aedb-2b5652d825fa",
+														"hue": 50
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "ae7dc3e6-3d74-473f-9f9c-7963fb951a3c",
+												"href": null,
+												"eabId": "EAB::ae7dc3e6-3d74-473f-9f9c-7963fb951a3c::61722303::227102678",
+												"type": "episode",
+												"name": "(Dub) Night of the End",
+												"description": "Deep in the forest, an unlikely rabble of Marley stragglers and island fugitives attempt to set their hatred aside and talk around a campfire without killing each other.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-03-06T12:00:00Z",
+												"season": 4,
+												"number": 25,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/ae7dc3e6-3d74-473f-9f9c-7963fb951a3c?base_image_bucket_name=image_manager&base_image=a501bd96-23de-4a43-9d39-28afc462d80e",
+														"hue": 235
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "3462dad9-7613-4f7e-ad93-c2351a3e931f",
+												"href": null,
+												"eabId": "EAB::3462dad9-7613-4f7e-ad93-c2351a3e931f::61698946::170902726",
+												"type": "episode",
+												"name": "(Sub) Night of the End",
+												"description": "Deep in the forest, an unlikely rabble of Marley stragglers and island fugitives attempt to set their hatred aside and talk around a campfire without killing each other.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-03-06T12:00:00Z",
+												"season": 4,
+												"number": 25,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/3462dad9-7613-4f7e-ad93-c2351a3e931f?base_image_bucket_name=image_manager&base_image=2d4bc324-992e-4915-9b6c-c48435ab17e7",
+														"hue": 235
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "8055c91d-0286-4b26-ad75-62ac5fb50f60",
+												"href": null,
+												"eabId": "EAB::8055c91d-0286-4b26-ad75-62ac5fb50f60::61722359::227613843",
+												"type": "episode",
+												"name": "(Dub) Traitor",
+												"description": "The Azumabito's flying boat is guarded by a port full of Jaegerists, but the Scouts are reluctant to kill their former friends. If they wish to avoid bloodshed, they can't afford their plan to go wrong.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-03-13T12:00:00Z",
+												"season": 4,
+												"number": 26,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/8055c91d-0286-4b26-ad75-62ac5fb50f60?base_image_bucket_name=image_manager&base_image=e1127407-3b12-407f-adaa-4288770bd170",
+														"hue": 205
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "ee484947-0dcb-4ead-a040-8aaabd3b6516",
+												"href": null,
+												"eabId": "EAB::ee484947-0dcb-4ead-a040-8aaabd3b6516::61699635::171923062",
+												"type": "episode",
+												"name": "(Sub) Traitor",
+												"description": "The Azumabito's flying boat is guarded by a port full of Jaegerists, but the Scouts are reluctant to kill their former friends. If they wish to avoid bloodshed, they can't afford their plan to go wrong.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-03-13T12:00:00Z",
+												"season": 4,
+												"number": 26,
+												"duration": 1458,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/ee484947-0dcb-4ead-a040-8aaabd3b6516?base_image_bucket_name=image_manager&base_image=ebd02ac1-b5b6-4465-9bd1-24c4ec8ffe08",
+														"hue": 205
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "508d174d-fc2f-40ba-938c-cef169e46cfd",
+												"href": null,
+												"eabId": "EAB::508d174d-fc2f-40ba-938c-cef169e46cfd::61722375::227613853",
+												"type": "episode",
+												"name": "(Dub) Retrospective",
+												"description": "For the flying boat to take off, the mechanics need half a day to service it. Knowing they'll never last that long with Jaegerist reinforcements on the way, the crew is forced to change their plans.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-03-20T12:00:00Z",
+												"season": 4,
+												"number": 27,
+												"duration": 1449,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/508d174d-fc2f-40ba-938c-cef169e46cfd?base_image_bucket_name=image_manager&base_image=26bce9f9-d8a8-4e6c-99c5-99883f38af77",
+														"hue": 180
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "a700d1ff-976d-48ca-a592-f9cb3b48ff9f",
+												"href": null,
+												"eabId": "EAB::a700d1ff-976d-48ca-a592-f9cb3b48ff9f::61700455::172906070",
+												"type": "episode",
+												"name": "(Sub) Retrospective",
+												"description": "For the flying boat to take off, the mechanics need half a day to service it. Knowing they'll never last that long with Jaegerist reinforcements on the way, the crew is forced to change their plans.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-03-20T12:00:00Z",
+												"season": 4,
+												"number": 27,
+												"duration": 1457,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/a700d1ff-976d-48ca-a592-f9cb3b48ff9f?base_image_bucket_name=image_manager&base_image=971a1118-bbba-4b79-a068-a8455d1ad39b",
+														"hue": 180
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "9c564fee-01d2-4094-8429-cd8698ceb8b2",
+												"href": null,
+												"eabId": "EAB::9c564fee-01d2-4094-8429-cd8698ceb8b2::61722376::227613859",
+												"type": "episode",
+												"name": "(Dub) The Dawn of Humanity",
+												"description": "Regardless of where it all began, Eren commits to his path of destruction during the Scouts' first visit to the Marleyan mainland, leaving Mikasa to wonder if things could've been different.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-04-03T12:00:00Z",
+												"season": 4,
+												"number": 28,
+												"duration": 1434,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/9c564fee-01d2-4094-8429-cd8698ceb8b2?base_image_bucket_name=image_manager&base_image=2baa523f-2071-48be-a11f-c8392f569ff3",
+														"hue": 355
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "15713e9d-313c-4d29-8bdf-8eef41fdeeb6",
+												"href": null,
+												"eabId": "EAB::15713e9d-313c-4d29-8bdf-8eef41fdeeb6::61702117::176303369",
+												"type": "episode",
+												"name": "(Sub) The Dawn of Humanity",
+												"description": "Regardless of where it all began, Eren commits to his path of destruction during the Scouts' first visit to the Marleyan mainland, leaving Mikasa to wonder if things could've been different.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2022-04-03T12:00:00Z",
+												"season": 4,
+												"number": 28,
+												"duration": 1443,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/15713e9d-313c-4d29-8bdf-8eef41fdeeb6?base_image_bucket_name=image_manager&base_image=a7bbe0db-75d3-4342-95b6-0be5f040239e",
+														"hue": 355
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "3488e755-bf9c-480e-9fa0-ffc2bf5fa045",
+												"href": null,
+												"eabId": "EAB::3488e755-bf9c-480e-9fa0-ffc2bf5fa045::61722978::225524378",
+												"type": "episode",
+												"name": "(Sub) The Final Chapters Special 1",
+												"description": "As the rumbling advances, the remaining members of the Scout Regiment race against the clock with their Marleyan and Azumabito allies to catch up to Eren and stop the rumbling before the rest of the world is crushed under the Wall Titans' feet.",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2023-03-03T12:00:00Z",
+												"season": 4,
+												"number": 29,
+												"duration": 3663,
+												"seriesName": "Attack on Titan",
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/3488e755-bf9c-480e-9fa0-ffc2bf5fa045?base_image_bucket_name=image_manager&base_image=b43cf88b-d5e2-4815-bc55-cfff9712f798",
+														"hue": 335
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											}
+										]
+									},
+									"upsell": {
+										"seasons": 4,
+										"episodes": 175,
+										"name": "Attack on Titan"
+									}
+								}
+							},
+							{
+								"title": "Extras",
+								"model": {
+									"type": "grid_collection",
+									"title": "Extras",
+									"collection": {
+										"id": "241",
+										"href": "https://discover.hulu.com/content/v5/hubs/series/9c91ffa3-dc20-48bf-8bc5-692e37c76d88/collections/241?schema=0&personalized_layout_id=H4sIAAAAAAAAAMu1MjIwMjYwMzAxNDcwrykptjI0szC1sLQwMTIAAgAi8yitHwAAAA",
+										"name": "Extras",
+										"theme": "grid_collection",
+										"enabledTileLinks": false,
+										"enableSignupModal": null,
+										"collectionHubPath": null,
+										"seasons": null,
+										"items": [
+											{
+												"id": "a2ee9bf4-37c5-4720-801c-ed5d88ea11b3",
+												"href": null,
+												"eabId": null,
+												"type": "extra",
+												"name": "Attack on Titan Final Season Part 2 - PV 2",
+												"description": "Attack on Titan Final Season trailer",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": "2013-04-07T00:00:00Z",
+												"season": null,
+												"number": null,
+												"duration": 100,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/a2ee9bf4-37c5-4720-801c-ed5d88ea11b3?base_image_bucket_name=image_manager&base_image=e99b22f9-64d2-4c99-b77b-594ac82273b8",
+														"hue": 40
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "c06aa0a3-2f69-4750-aaf1-f9cd439c50b9",
+												"href": null,
+												"eabId": null,
+												"type": "extra",
+												"name": "(Sub) Since That Day",
+												"description": "In the wake of the mission to take back Trost, Eren recollects the events that led to humanity's current state - starting with the day the Colossal Titan first appeared in Shiganshina.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Animation",
+													"Fantasy",
+													"International",
+													"Anime"
+												],
+												"premiereDate": null,
+												"season": null,
+												"number": null,
+												"duration": 1459,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/c06aa0a3-2f69-4750-aaf1-f9cd439c50b9?base_image_bucket_name=image_manager&base_image=a4c718d4-11ee-4885-9dfa-ccb17b8dbbfe",
+														"hue": 205
+													},
+													"horizontalProgramTile": null,
+													"verticalHero": null,
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											}
+										]
+									},
+									"upsell": {
+										"seasons": 4,
+										"episodes": 175,
+										"name": "Attack on Titan"
+									}
+								}
+							},
+							{
+								"title": "Details",
+								"model": {
+									"type": "collection_details",
+									"collection": {
+										"theme": "details",
+										"name": "About this Show"
+									},
+									"entityType": "series",
+									"tags": [
+										2013
+									],
+									"name": "Attack on Titan",
+									"credits": [
+										{
+											"prefix": "Starring:",
+											"seoSchemaProp": "actor",
+											"items": [
+												"Yûki Kaji",
+												"Yui Ishikawa",
+												"Marina Inoue",
+												"Kisho Taniyama",
+												"Yu Shimamura"
+											],
+											"truncatedItems": [
+												"Yûki Kaji",
+												"Yui Ishikawa",
+												"Marina Inoue"
+											]
+										}
+									],
+									"avFeatures": {
+										"items": [
+											"hd"
+										],
+										"truncatedItems": [
+											"hd"
+										]
+									},
+									"description": "From the director of Death Note comes Attack on Titan. Many years ago, humanity was forced to retreat behind the towering walls of a fortified city to escape the massive, man-eating Titans that roamed the land outside their fortress. This is their story.",
+									"rating": "TVMA",
+									"genres": [
+										{
+											"name": "Action",
+											"hubPath": "/hub/action-tv"
+										},
+										{
+											"name": "Animation",
+											"hubPath": null
+										},
+										{
+											"name": "Fantasy",
+											"hubPath": "/hub/fantasy-tv"
+										},
+										{
+											"name": "International",
+											"hubPath": "/hub/international-tv"
+										},
+										{
+											"name": "Anime",
+											"hubPath": "/hub/anime-tv"
+										}
+									]
+								}
+							}
+						],
+						"heroSliderCtaUrl": "",
+						"heroSliderCtaLegalText": "",
+						"heroSliderCtaDesc": "",
+						"heroSliderCtaText": "",
+						"heroSliderCtaPremiumDesc": "",
+						"network": "Attack on Titan",
+						"heroSliderCtaDisclaimer": "",
+						"metrics": {
+							"collectionIndex": 0
+						}
+					},
+					{
+						"type": "collection",
+						"collections": [
+							{
+								"model": {
+									"type": "simple_collection",
+									"title": "You May Also Like",
+									"collection": {
+										"id": "95",
+										"href": "https://discover.hulu.com/content/v5/hubs/series/9c91ffa3-dc20-48bf-8bc5-692e37c76d88/collections/95?schema=0&personalized_layout_id=H4sIAAAAAAAAAMu1MjIwMjYwMzAxNDcwrykptjI0szC1sLQwMTIAAgAi8yitHwAAAA",
+										"name": "You May Also Like",
+										"theme": "simple_collection",
+										"enabledTileLinks": true,
+										"enableSignupModal": null,
+										"collectionHubPath": null,
+										"seasons": null,
+										"items": [
+											{
+												"id": "d81e6428-58f1-4e2b-904b-5eb1d65d6640",
+												"href": "/series/demon-slayer-kimetsu-no-yaiba-entertainment-district-arc-d81e6428-58f1-4e2b-904b-5eb1d65d6640",
+												"eabId": null,
+												"type": "series",
+												"name": "Demon Slayer: Kimetsu No Yaiba Entertainment District Arc",
+												"description": "Demon Slayer: Kimetsu no Yaiba Entertainment District Arc follows Tanjiro and his friends' next mission after the Mugen Train. Alongside one of the Demon Slayer Corps' top ranked swordsmen, Sound Hashira Tengen Uzui, Tanjiro heads to a place where demons dwell – the Entertainment District.",
+												"rating": null,
+												"genres": [
+													"Fantasy",
+													"Drama",
+													"Action",
+													"Anime",
+													"Animation"
+												],
+												"premiereDate": "2021-12-05T12:00:00Z",
+												"season": null,
+												"number": null,
+												"duration": null,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/d81e6428-58f1-4e2b-904b-5eb1d65d6640?base_image_bucket_name=image_manager&base_image=d7b11cef-a059-4479-a081-8ac2a8971328",
+														"hue": 340
+													},
+													"horizontalProgramTile": {
+														"path": "https://img.hulu.com/user/v3/artwork/d81e6428-58f1-4e2b-904b-5eb1d65d6640?base_image_bucket_name=image_manager&base_image=accc8a48-57e6-4c9f-95a7-a5e4f66742b9",
+														"hue": 355
+													},
+													"verticalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/d81e6428-58f1-4e2b-904b-5eb1d65d6640?base_image_bucket_name=image_manager&base_image=5b5164c0-4adf-43d5-af62-f5dde07ec32f",
+														"hue": 340
+													},
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "7b71b5a4-560b-4d8b-98c4-c5dee6004c21",
+												"href": "/series/chainsaw-man-7b71b5a4-560b-4d8b-98c4-c5dee6004c21",
+												"eabId": null,
+												"type": "series",
+												"name": "Chainsaw Man",
+												"description": "A teenage boy drowning in debt is forced to hunt down devils with his pet devil dog Pochita until he's betrayed and killed. In an unexpected turn of events, Pochita merges with his dead body and grants him the power of a Chainsaw Man!",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Adventure",
+													"Animation",
+													"Anime"
+												],
+												"premiereDate": "2022-10-11T12:00:00Z",
+												"season": null,
+												"number": null,
+												"duration": null,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/7b71b5a4-560b-4d8b-98c4-c5dee6004c21?base_image_bucket_name=image_manager&base_image=bd033d11-72ab-4100-a729-59eee4dc5523",
+														"hue": 205
+													},
+													"horizontalProgramTile": {
+														"path": "https://img3.hulu.com/user/v3/artwork/7b71b5a4-560b-4d8b-98c4-c5dee6004c21?base_image_bucket_name=image_manager&base_image=7002e231-e4a5-4878-8f48-ea4b5a95348c",
+														"hue": 205
+													},
+													"verticalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/7b71b5a4-560b-4d8b-98c4-c5dee6004c21?base_image_bucket_name=image_manager&base_image=24133799-ae73-49ab-910a-4e483e68826f",
+														"hue": 205
+													},
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": {
+														"path": "https://img3.hulu.com/user/v3/artwork/7b71b5a4-560b-4d8b-98c4-c5dee6004c21?base_image_bucket_name=image_manager&base_image=bacd5907-ef7d-4bd7-a280-27038cd44051"
+													}
+												}
+											},
+											{
+												"id": "b4859a95-39ba-4051-a550-256c42e70a1d",
+												"href": "/series/my-hero-academia-b4859a95-39ba-4051-a550-256c42e70a1d",
+												"eabId": null,
+												"type": "series",
+												"name": "My Hero Academia",
+												"description": "Despite being born powerless into a super-powered world, Izuku refuses to give up on his dream of becoming a hero. He enrolls himself in a prestigious hero academy with a deadly entrance exam. To make the grade, he’ll have to put in some serious study time with the mightiest hero of all.",
+												"rating": "TV14",
+												"genres": [
+													"Comedy",
+													"Superheroes",
+													"Anime",
+													"Fantasy",
+													"Action",
+													"Animation"
+												],
+												"premiereDate": "2016-04-03T00:00:00Z",
+												"season": null,
+												"number": null,
+												"duration": null,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/b4859a95-39ba-4051-a550-256c42e70a1d?base_image_bucket_name=image_manager&base_image=c4cd766d-43e1-4a07-8af3-f04f58499c8e",
+														"hue": 275
+													},
+													"horizontalProgramTile": {
+														"path": "https://img1.hulu.com/user/v3/artwork/b4859a95-39ba-4051-a550-256c42e70a1d?base_image_bucket_name=image_manager&base_image=43d9c367-3c25-4c7c-ad51-f316189d93a6",
+														"hue": 265
+													},
+													"verticalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/b4859a95-39ba-4051-a550-256c42e70a1d?base_image_bucket_name=image_manager&base_image=a72ffba8-cc05-4371-b100-3744eee81f21",
+														"hue": 170
+													},
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": {
+														"path": "https://img1.hulu.com/user/v3/artwork/b4859a95-39ba-4051-a550-256c42e70a1d?base_image_bucket_name=image_manager&base_image=64ff527d-c906-4262-be77-7f517d2c18d8"
+													}
+												}
+											},
+											{
+												"id": "0921b58c-bef9-4a4d-a677-03ec7745428c",
+												"href": "/series/dragon-ball-super-0921b58c-bef9-4a4d-a677-03ec7745428c",
+												"eabId": null,
+												"type": "series",
+												"name": "Dragon Ball Super",
+												"description": "After defeating Majin Buu, life is peaceful once again. Ordered by Chi-chi to earn money, Goku works even as he wants to train even more. Meanwhile, Goten, about to become a brother-in-law to Videl, sets out on a journey with Trunks to find her a present.",
+												"rating": "TV14",
+												"genres": [
+													"Fantasy",
+													"Action",
+													"Adventure",
+													"Anime",
+													"Animation"
+												],
+												"premiereDate": "2015-06-20T20:00:00Z",
+												"season": null,
+												"number": null,
+												"duration": null,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/0921b58c-bef9-4a4d-a677-03ec7745428c?base_image_bucket_name=image_manager&base_image=ba9b444e-c58d-4830-aa02-925fe67f9d95",
+														"hue": 270
+													},
+													"horizontalProgramTile": {
+														"path": "https://img4.hulu.com/user/v3/artwork/0921b58c-bef9-4a4d-a677-03ec7745428c?base_image_bucket_name=image_manager&base_image=3e73354d-05ba-45e9-8c84-1e38265b7e22",
+														"hue": 180
+													},
+													"verticalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/0921b58c-bef9-4a4d-a677-03ec7745428c?base_image_bucket_name=image_manager&base_image=037c5734-a653-448c-a404-d473b0dbe03b",
+														"hue": 170
+													},
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": {
+														"path": "https://img4.hulu.com/user/v3/artwork/0921b58c-bef9-4a4d-a677-03ec7745428c?base_image_bucket_name=image_manager&base_image=5ac7a0ae-3699-44df-8236-c0d299b8e5c2"
+													}
+												}
+											},
+											{
+												"id": "54a25fcf-a472-4d40-9968-13e2957e5abf",
+												"href": "/series/one-punch-man-54a25fcf-a472-4d40-9968-13e2957e5abf",
+												"eabId": null,
+												"type": "series",
+												"name": "One-Punch Man",
+												"description": "Saitama only became a hero for fun, but after three years of “special” training, he finds that he can beat even the mightiest opponents with a single punch. Though he faces new enemies every day, it turns out being devastatingly powerful is actually kind of a bore. Can a hero be too strong?",
+												"rating": "TVMA",
+												"genres": [
+													"Adventure",
+													"Comedy",
+													"Action",
+													"Fantasy",
+													"Animation",
+													"Anime",
+													"Science Fiction"
+												],
+												"premiereDate": "2015-10-04T12:00:00Z",
+												"season": null,
+												"number": null,
+												"duration": null,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/54a25fcf-a472-4d40-9968-13e2957e5abf?base_image_bucket_name=image_manager&base_image=38e27cd2-8318-41c3-8348-616d3ed1c9dc",
+														"hue": 30
+													},
+													"horizontalProgramTile": {
+														"path": "https://img4.hulu.com/user/v3/artwork/54a25fcf-a472-4d40-9968-13e2957e5abf?base_image_bucket_name=image_manager&base_image=2c2b3679-5094-4299-b39f-74859543235c",
+														"hue": 355
+													},
+													"verticalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/54a25fcf-a472-4d40-9968-13e2957e5abf?base_image_bucket_name=image_manager&base_image=e35e681e-0574-4b25-a281-44f4a15b4ecb",
+														"hue": 0
+													},
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": {
+														"path": "https://img4.hulu.com/user/v3/artwork/54a25fcf-a472-4d40-9968-13e2957e5abf?base_image_bucket_name=image_manager&base_image=5ad2cdfa-4965-4b3d-8414-584b978074c5"
+													}
+												}
+											},
+											{
+												"id": "2c3e4b00-30d9-434d-bccc-cf346e40e868",
+												"href": "/series/demon-slayer-kimetsu-no-yaiba-2c3e4b00-30d9-434d-bccc-cf346e40e868",
+												"eabId": null,
+												"type": "series",
+												"name": "Demon Slayer Kimetsu No Yaiba",
+												"description": "Bloodthirsty demons lurk in the woods, and young Tanjiro takes it upon himself to protect his family. That is, until the day that everything is taken from him in a vicious slaughter. Now, all he has left is his sister, and she’s not even human anymore.",
+												"rating": "TV14",
+												"genres": [
+													"Action",
+													"Animation",
+													"Adventure",
+													"Fantasy",
+													"Anime"
+												],
+												"premiereDate": "2019-04-06T00:00:00Z",
+												"season": null,
+												"number": null,
+												"duration": null,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/2c3e4b00-30d9-434d-bccc-cf346e40e868?base_image_bucket_name=image_manager&base_image=263d23b6-9efc-4bb5-b0b5-62aa8ca28444",
+														"hue": 185
+													},
+													"horizontalProgramTile": {
+														"path": "https://img2.hulu.com/user/v3/artwork/2c3e4b00-30d9-434d-bccc-cf346e40e868?base_image_bucket_name=image_manager&base_image=15168dce-421a-4acd-9869-54bac2c22330",
+														"hue": 185
+													},
+													"verticalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/2c3e4b00-30d9-434d-bccc-cf346e40e868?base_image_bucket_name=image_manager&base_image=8735ea33-7a18-4a77-9233-83b2fa47502e",
+														"hue": 195
+													},
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "65d158d4-443f-44c7-bd2c-eae39f6c60e9",
+												"href": "/series/spy-x-family-65d158d4-443f-44c7-bd2c-eae39f6c60e9",
+												"eabId": null,
+												"type": "series",
+												"name": "SPY x FAMILY",
+												"description": "World peace is at stake and secret agent Twilight must undergo his most difficult mission yet--pretend to be a family man. Posing as a loving husband and father, he'll infiltrate an elite school to get close to a high-profile politician.",
+												"rating": null,
+												"genres": [
+													"Action",
+													"Comedy",
+													"Animation",
+													"Anime"
+												],
+												"premiereDate": "2022-04-09T12:00:00Z",
+												"season": null,
+												"number": null,
+												"duration": null,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/65d158d4-443f-44c7-bd2c-eae39f6c60e9?base_image_bucket_name=image_manager&base_image=94664afe-c49c-4246-9a1d-76e9953e892e",
+														"hue": 0
+													},
+													"horizontalProgramTile": {
+														"path": "https://img3.hulu.com/user/v3/artwork/65d158d4-443f-44c7-bd2c-eae39f6c60e9?base_image_bucket_name=image_manager&base_image=c43af19d-f5a1-4be2-8c78-db913ea4e1e5",
+														"hue": 0
+													},
+													"verticalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/65d158d4-443f-44c7-bd2c-eae39f6c60e9?base_image_bucket_name=image_manager&base_image=325f2788-cf4f-404d-b3b8-5cdb7faf1b58",
+														"hue": 355
+													},
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": {
+														"path": "https://img3.hulu.com/user/v3/artwork/65d158d4-443f-44c7-bd2c-eae39f6c60e9?base_image_bucket_name=image_manager&base_image=edf934a8-6e69-4d16-842a-241db7ba23d5"
+													}
+												}
+											},
+											{
+												"id": "3f2ffb64-2424-44a5-b229-4371dccb1d6f",
+												"href": "/series/jojos-bizarre-adventure-3f2ffb64-2424-44a5-b229-4371dccb1d6f",
+												"eabId": null,
+												"type": "series",
+												"name": "JoJo’s Bizarre Adventure",
+												"description": "Based on author Hirohiko Araki’s groundbreaking Shonen Jump manga series, JoJo’s Bizarre Adventure follows the multigenerational tale of the heroic Joestar family and their never-ending battle against evil.",
+												"rating": "TVMA",
+												"genres": [
+													"Fantasy",
+													"Music",
+													"Adventure",
+													"Anime",
+													"International",
+													"Action",
+													"Animation"
+												],
+												"premiereDate": "2012-10-05T00:00:00Z",
+												"season": null,
+												"number": null,
+												"duration": null,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/3f2ffb64-2424-44a5-b229-4371dccb1d6f?base_image_bucket_name=image_manager&base_image=d9861738-2b1e-4c2d-a945-e3dedc6197c5",
+														"hue": 350
+													},
+													"horizontalProgramTile": {
+														"path": "https://img4.hulu.com/user/v3/artwork/3f2ffb64-2424-44a5-b229-4371dccb1d6f?base_image_bucket_name=image_manager&base_image=1d9c8ecb-f2ef-4d3d-a12f-50bdf2dcefa4",
+														"hue": 330
+													},
+													"verticalHero": {
+														"path": "https://img4.hulu.com/user/v3/artwork/3f2ffb64-2424-44a5-b229-4371dccb1d6f?base_image_bucket_name=image_manager&base_image=f3242b25-670c-4bec-b5ca-c5d6189e4ad2",
+														"hue": 350
+													},
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "f6451467-97a8-4ddf-9ae8-e9e4cbb53fc8",
+												"href": "/series/black-clover-f6451467-97a8-4ddf-9ae8-e9e4cbb53fc8",
+												"eabId": null,
+												"type": "series",
+												"name": "Black Clover",
+												"description": "In a world where magic is everything, Asta and Yuno are both found abandoned at a church on the same day. While Yuno is gifted with exceptional magical powers, Asta is the only one in this world without any. At the age of fifteen, both receive grimoires, magic books that amplify their holder’s magic. Asta's is a rare Grimoire of Anti-Magic that negates and repels his opponent’s spells. Being opposite but good rivals, Yuno and Asta are ready for the hardest of challenges to achieve their common dream: to be the Wizard King. Giving up is never an option!",
+												"rating": "TV14",
+												"genres": [
+													"Anime",
+													"Fantasy",
+													"Action",
+													"Adventure"
+												],
+												"premiereDate": "2017-10-03T00:00:00Z",
+												"season": null,
+												"number": null,
+												"duration": null,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/f6451467-97a8-4ddf-9ae8-e9e4cbb53fc8?base_image_bucket_name=image_manager&base_image=a2184d72-dfd3-4569-b030-206a01404f94",
+														"hue": 60
+													},
+													"horizontalProgramTile": {
+														"path": "https://img2.hulu.com/user/v3/artwork/f6451467-97a8-4ddf-9ae8-e9e4cbb53fc8?base_image_bucket_name=image_manager&base_image=1643777a-1843-4eb5-88f2-af81563d0391",
+														"hue": 60
+													},
+													"verticalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/f6451467-97a8-4ddf-9ae8-e9e4cbb53fc8?base_image_bucket_name=image_manager&base_image=bc1a1c50-6786-4cf7-ae75-75de958b64e1",
+														"hue": 35
+													},
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": {
+														"path": "https://img2.hulu.com/user/v3/artwork/f6451467-97a8-4ddf-9ae8-e9e4cbb53fc8?base_image_bucket_name=image_manager&base_image=e1d1e382-d176-4f15-9b81-0c2cfc10785c"
+													}
+												}
+											},
+											{
+												"id": "e6f09891-7847-42f5-91eb-1bc17fe8dc5b",
+												"href": "/series/yu-yu-hakusho-e6f09891-7847-42f5-91eb-1bc17fe8dc5b",
+												"eabId": null,
+												"type": "series",
+												"name": "Yu Yu Hakusho",
+												"description": "When delinquent Yusuke dies saving someone else, he gets a second shot at life as a Spirit Detective. With his former rival, Kuwabara, and demons Kurama and Hiei, Yusuke takes on the monsters and humans who desire to rule the three realms of reality.",
+												"rating": "TVPG",
+												"genres": [
+													"Fantasy",
+													"Animation",
+													"Anime",
+													"Science Fiction",
+													"Action",
+													"Adventure"
+												],
+												"premiereDate": "1992-10-10T12:00:00Z",
+												"season": null,
+												"number": null,
+												"duration": null,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/e6f09891-7847-42f5-91eb-1bc17fe8dc5b?base_image_bucket_name=image_manager&base_image=1fbffd99-733f-4225-859d-0811a65b7085",
+														"hue": 190
+													},
+													"horizontalProgramTile": {
+														"path": "https://img2.hulu.com/user/v3/artwork/e6f09891-7847-42f5-91eb-1bc17fe8dc5b?base_image_bucket_name=image_manager&base_image=017fa0ca-38f1-4a35-b9e5-0373b02a5097",
+														"hue": 55
+													},
+													"verticalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/e6f09891-7847-42f5-91eb-1bc17fe8dc5b?base_image_bucket_name=image_manager&base_image=e2572bb3-49d6-498a-bf91-43cec8e9fa24",
+														"hue": 190
+													},
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "80584c86-347a-415a-8dc1-7f039e7ce3ac",
+												"href": "/series/devils-line-80584c86-347a-415a-8dc1-7f039e7ce3ac",
+												"eabId": null,
+												"type": "series",
+												"name": "Devils' Line",
+												"description": "In a world where devils blend in with the rest of human population, half-devil Anzai uses his devil-born gifts to protect Tokyo from vampire-related crimes. His strong will of never drinking blood becomes severely tested when he falls in love with the girl he rescued from a devil's attack. Will Anzai be able to resist the urge of his demon instincts?",
+												"rating": "TVMA",
+												"genres": [
+													"Action",
+													"Drama",
+													"Fantasy",
+													"Romance",
+													"Animation",
+													"Anime",
+													"Science Fiction",
+													"Adventure"
+												],
+												"premiereDate": "2018-04-10T12:00:00Z",
+												"season": null,
+												"number": null,
+												"duration": null,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/80584c86-347a-415a-8dc1-7f039e7ce3ac?base_image_bucket_name=image_manager&base_image=7048c537-dd5c-400d-b8bb-56b41118c0a8",
+														"hue": 220
+													},
+													"horizontalProgramTile": {
+														"path": "https://img1.hulu.com/user/v3/artwork/80584c86-347a-415a-8dc1-7f039e7ce3ac?base_image_bucket_name=image_manager&base_image=d19e013e-f9f5-4ba1-aa7e-116147b164a0",
+														"hue": 220
+													},
+													"verticalHero": {
+														"path": "https://img1.hulu.com/user/v3/artwork/80584c86-347a-415a-8dc1-7f039e7ce3ac?base_image_bucket_name=image_manager&base_image=731f075a-137e-44c2-bb16-f4fa413a1a4a",
+														"hue": 220
+													},
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "aeb20011-e054-483b-8422-39ad643fc224",
+												"href": "/series/assassination-classroom-aeb20011-e054-483b-8422-39ad643fc224",
+												"eabId": null,
+												"type": "series",
+												"name": "Assassination Classroom",
+												"description": "Forget about homework. The students of Class 3E have a more important assignment: kill the teacher! Their tentacle-d sensei moves at Mach 20, and he’s out to conquer the classroom after destroying most of the moon!",
+												"rating": "TV14",
+												"genres": [
+													"Fantasy",
+													"International",
+													"Action",
+													"Anime",
+													"Animation"
+												],
+												"premiereDate": "2015-01-09T00:00:00Z",
+												"season": null,
+												"number": null,
+												"duration": null,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/aeb20011-e054-483b-8422-39ad643fc224?base_image_bucket_name=image_manager&base_image=ae42ad06-e559-49cb-ba03-4ae4d3c4eae0",
+														"hue": 55
+													},
+													"horizontalProgramTile": {
+														"path": "https://img2.hulu.com/user/v3/artwork/aeb20011-e054-483b-8422-39ad643fc224?base_image_bucket_name=image_manager&base_image=2f4c341a-37e1-4ce1-86ff-4d4f16922a24",
+														"hue": 55
+													},
+													"verticalHero": {
+														"path": "https://img2.hulu.com/user/v3/artwork/aeb20011-e054-483b-8422-39ad643fc224?base_image_bucket_name=image_manager&base_image=f57f4acd-8895-49d6-97a3-dfbca44873ea",
+														"hue": 55
+													},
+													"networkTile": {
+														"path": "https://img2.hulu.com/user/v3/artwork/75259146-c522-496a-a109-c874bd38a431?base_image_bucket_name=image_manager&base_image=f79dc8cf-b0d8-45d2-bb87-5b5a5cf1f299"
+													},
+													"watermark": {
+														"path": "https://img2.hulu.com/user/v3/artwork/75259146-c522-496a-a109-c874bd38a431?base_image_bucket_name=image_manager&base_image=e98f60f9-7b4e-4306-b500-4ca22f456fde"
+													},
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "f1f053e2-ed2e-437c-94c6-c4e557e79bbc",
+												"href": "/series/black-butler-f1f053e2-ed2e-437c-94c6-c4e557e79bbc",
+												"eabId": null,
+												"type": "series",
+												"name": "Black Butler",
+												"description": "Ciel Phantomhive was born into a life of luxury, only to have his parents murdered before his eyes. Wrought with grief, he summoned a devilish servant, Sebastian, to help him track down - and suitably punish - the fiends who made him an orphan.",
+												"rating": "TV14",
+												"genres": [
+													"Animation",
+													"Anime",
+													"Adventure",
+													"International",
+													"Action",
+													"Supernatural"
+												],
+												"premiereDate": "2008-10-30T12:00:00Z",
+												"season": null,
+												"number": null,
+												"duration": null,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/f1f053e2-ed2e-437c-94c6-c4e557e79bbc?base_image_bucket_name=image_manager&base_image=e131f8ce-69df-4e2a-ad52-3228afc4c9d1",
+														"hue": 40
+													},
+													"horizontalProgramTile": {
+														"path": "https://img.hulu.com/user/v3/artwork/f1f053e2-ed2e-437c-94c6-c4e557e79bbc?base_image_bucket_name=image_manager&base_image=a4561687-5070-49b7-8f7f-ce51ee97c26c",
+														"hue": 40
+													},
+													"verticalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/f1f053e2-ed2e-437c-94c6-c4e557e79bbc?base_image_bucket_name=image_manager&base_image=dff2fac2-1dbf-4f32-bc1b-4eb51da3695f",
+														"hue": 40
+													},
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "fd1aee21-6a0f-417c-ba55-57c5b0d22002",
+												"href": "/series/parasyte-the-maxim-fd1aee21-6a0f-417c-ba55-57c5b0d22002",
+												"eabId": null,
+												"type": "series",
+												"name": "Parasyte: The Maxim",
+												"description": "One night, a quiet invasion takes place. Across the world, alien beings, known as Parasytes, fall to earth and begin possessing humans one by one with the rest of humanity none the wiser. Shinichi Izumi is one such victim. But when his would-be invader fails to take over his brain, and takes root in his arm, Shinichi finds himself forced to share his body with a horrific creature that has a mind and an agenda all its own.",
+												"rating": "TVMA",
+												"genres": [
+													"Science Fiction",
+													"Anime",
+													"International",
+													"Animation",
+													"Horror",
+													"Supernatural"
+												],
+												"premiereDate": "2014-10-08T00:00:00Z",
+												"season": null,
+												"number": null,
+												"duration": null,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/fd1aee21-6a0f-417c-ba55-57c5b0d22002?base_image_bucket_name=image_manager&base_image=19543ac4-974c-4648-b33f-b2def6416240",
+														"hue": 210
+													},
+													"horizontalProgramTile": {
+														"path": "https://img.hulu.com/user/v3/artwork/fd1aee21-6a0f-417c-ba55-57c5b0d22002?base_image_bucket_name=image_manager&base_image=a7d36866-2740-4bf6-ad09-836d99c779c4",
+														"hue": 210
+													},
+													"verticalHero": {
+														"path": "https://img.hulu.com/user/v3/artwork/fd1aee21-6a0f-417c-ba55-57c5b0d22002?base_image_bucket_name=image_manager&base_image=2d12bf18-f585-493f-ab83-bb7a83b47ef2",
+														"hue": 210
+													},
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											},
+											{
+												"id": "9065c6f1-4d2d-4150-a1ef-58bced498809",
+												"href": "/series/death-note-9065c6f1-4d2d-4150-a1ef-58bced498809",
+												"eabId": null,
+												"type": "series",
+												"name": "Death Note",
+												"description": "Light Yagami is an ace student with great prospects and he's bored out of his mind.  But all that changes when he finds the Death Note, a notebook dropped by a rogue Shinigami death god.  Any human whose name is written in the notebook dies, and now Light has vowed to use the power of the Death Note to rid the world of evil.  But when criminals begin dropping dead, the authorities send the legendary detective L to track down the killer.  With L hot on his heels, will Light lose sight of his noble goal...or his life?",
+												"rating": "TV14",
+												"genres": [
+													"Mystery",
+													"Crime",
+													"Thriller",
+													"Drama",
+													"Anime",
+													"Animation"
+												],
+												"premiereDate": "2006-10-03T00:00:00Z",
+												"season": null,
+												"number": null,
+												"duration": null,
+												"seriesName": null,
+												"artwork": {
+													"horizontalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/9065c6f1-4d2d-4150-a1ef-58bced498809?base_image_bucket_name=image_manager&base_image=e2cdb1f3-36f5-4d13-8ee7-2654bbc56e0d",
+														"hue": 180
+													},
+													"horizontalProgramTile": {
+														"path": "https://img3.hulu.com/user/v3/artwork/9065c6f1-4d2d-4150-a1ef-58bced498809?base_image_bucket_name=image_manager&base_image=76ff493f-55aa-4f5b-b9f0-d22ce651a57c",
+														"hue": 175
+													},
+													"verticalHero": {
+														"path": "https://img3.hulu.com/user/v3/artwork/9065c6f1-4d2d-4150-a1ef-58bced498809?base_image_bucket_name=image_manager&base_image=ed1ee7da-e435-4890-bb10-cdd1f9e924c6",
+														"hue": 175
+													},
+													"networkTile": null,
+													"watermark": null,
+													"titleArtwork": null
+												}
+											}
+										]
+									},
+									"enabledTileLinks": true
+								}
+							}
+						],
+						"metrics": {
+							"collectionIndex": 3
+						}
+					},
+					{
+						"type": "player",
+						"metrics": {}
+					},
+					{
+						"type": "signup_modal",
+						"name": "Attack on Titan",
+						"availableSeasons": 4,
+						"episodeCount": 175,
+						"ctaText": "Start Your Free Trial",
+						"ctaUrl": "/signup/go/one-hulu",
+						"ctaDownloadAppText": "Watch Now",
+						"legalText": "For new subscribers only",
+						"bodyText": "No hidden fees, equipment rentals, or installation appointments.",
+						"contentType": "series",
+						"isOriginalContent": false,
+						"premiereDate": "2013-04-07T00:00:00Z",
+						"requirePremium": false,
+						"metrics": {}
+					},
+					{
+						"type": "tier_modal",
+						"id": "sportsaddon-modal",
+						"name": "Sports Add-on",
+						"price": "$9.99/month",
+						"body": "Stream every touchdown from every game, every Sunday during the NFL regular season with NFL RedZone, along with hundreds of hours of live sports –motorsports (MAVTV), horse racing (FanDuel TV/FanDuel Racing) to hunting and fishing (Outdoor Channel, Sportsman Channel).",
+						"shouldRandomize": false,
+						"logos": [
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/ec8159e7d204003c0e46f21072dacab58d86a496700beb4ed4f77b7b60e3e37b/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/2f78fe4d217c096d158f00eece7e8a9c67d567e9d238abd6297099e7fd633ed6/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/3bc25da921e02361cd29dd5b78151706837ddec42299b1eab4c0bec8a7b50e2c/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/b3ffc383fa43826d54610e1326c42c293242949f6b4f7982104565da69faa5df/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/d8721a1c2ba3675a48c6a8e983111d545786ab7ab8dfafc3c9f7ba37b0ffc49a/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/a6921dfd5061f532f63eb7ddc56aa39b358ad87231dae437dd67ccc25b7a38b4/original"
+							}
+						],
+						"metrics": {}
+					},
+					{
+						"type": "tier_modal",
+						"id": "espanol-modal",
+						"name": "Español Add-on",
+						"price": "$4.99/month",
+						"body": "Enjoy a collection of popular favorites in Spanish – CNN en Español, Discovery en Español, Discovery Familia, ESPN Deportes, History Channel en Español, and Universo.",
+						"shouldRandomize": false,
+						"logos": [
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/8a4ff3716ac76a0ede555b002589b578e78ee1ac75d215a7da02c0528186d234/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/f4ca338e72c6e02d6deab6830014ee5ed15c68575213041920fe25ce9a26ca36/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/be200cf2ea57d1a262eba57ce73e15065141a1e6c96fe6814d4e9b40a7b23065/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/eb493afba9617f1318eaf238366139a26a85dba1cac4eb62bcaba8f8dd61098a/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/de8fafa9f0e023116af53a93e817597ac15a66acdcc510763a27541236ae1405/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/63c356517b4099cc674965b859a267ecdf732f795f3ddbeab46512c01717ffa9/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/571968287ec7b1087b382cc96d4f7501965c6eb12cf5ac7969d6149fc9333935/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/e1ab4d05132815c111c7e6c1ce910453166d3cd7a6cb30cd8a8bd7f09602a27a/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/e28572c3b3c69d36d5f031137fa71c66fc754cff7dca94e68561744180395ad7/original"
+							}
+						],
+						"metrics": {}
+					},
+					{
+						"type": "tier_modal",
+						"id": "entertainment-modal",
+						"name": "Entertainment Add-on",
+						"price": "$7.99/month",
+						"body": "Stay current with additional news, entertainment, and lifestyle programming from American Heroes Channel, BET Her, Boomerang, CNBC World, Cooking Channel, Crime + Investigation, Destination America, Discovery Family, Discovery Life, Military History Channel, MTV2, MTV Classic, Nick Toons, Science, and Teen Nick.",
+						"shouldRandomize": false,
+						"logos": [
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/0ab82bfcacc470262d593761311df615afcf06a225fc76a1b7b3639c95cb05ec/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/ddb329360666ec283f41a6822bbaca2bf0f92fa3daa87babcfd4291391f09d31/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/607dcb9acf16bc2de181ab1e3e6457ad45d62d5aef771a341b5b7cb04e4f183e/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/464e555c84b580351a4b2e193459f07baed80854ae034cd1350a69a62a1bf286/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/aa6003125241eff00c7ddb6f0b6d37819c334f3b704d39110fa29ddd6e9ce796/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/9f060436044ac4ce14bacc4af832136c3c2517a9d666f6cb5162b0c0f512c639/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/e1a807a8f5cb7d6af4a342b8deb773d3aa795a958afbdd55b480b1ddd13120e0/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/e54039aae189599b75fa42b5dcf55d6d0e5e88d6ffff56dadd1c2edc920205b6/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/d7a43cc2d3d22735247ce06b828353ed62ec6262b7688f3d87df515039f7034f/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/343f2b0b596bb159366dd888adeba966c767cbcd75180d4a6a52d5cc1c42d342/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/1106f17568cac392e1f156ebdfd90d202a378619a3a682ae39e5b82e43251b55/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/4b08184bade28c32b290713a03989bd257dc4fed610cf0e9e7b3d8950b0deff8/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/702f02d9c9b5d79f79764011031fd74d27ce21755cf8290d2852534c54b2c1a4/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/f662a0239f3f4a4b7c1dc594f17dd0dd01a1af95e64ad28a4c5376f50ab265ba/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/e1e9230a34e2669d2f7ad66fad3b79f32153f169f671f0774db60140af0fe438/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/415f94db963a7e42a5959b26aee3d10202b300455cbcddbb791834e56b5e25d5/original"
+							},
+							{
+								"name": "",
+								"icon": "//cnbl-cdn.bamgrid.com/assets/ab64b682b66e652746b115a86bc3043e15453da2bdd94a446ebd6a35c3240b48/original"
+							}
+						],
+						"metrics": {}
+					},
+					{
+						"type": "modal",
+						"body": "18+ only. Any free trials valid for new and eligible returning subscribers only. For personal and non-commercial use only. Live TV is available in the 50 United States and the District of Columbia only. Compatible device and high-speed, broadband Internet connection required. Multiple concurrent streams and HD content may require higher bandwidth. Streaming content may count against your data usage. Location data required to access content. Live TV may vary by subscription and location. Click here to check channel availability in your area. Programming subject to regional availability, blackouts, and device restrictions. Number of permitted concurrent streams will vary based on the terms of your subscription. Pricing, channels, features, content, and compatible devices subject to change. Please review our Terms of Use (<a href=\"https://www.hulu.com/terms\" target=\"_blank\">https://www.hulu.com/terms</a>) and Privacy Policy (<a href=\"https://privacy.thewaltdisneycompany.com/en/current-privacy-policy/\" target=\"_blank\">https://privacy.thewaltdisneycompany.com/en/current-privacy-policy/</a>).\n<br>\n<br>\nU.S. residents. Includes certain combinations of Disney+, Hulu, and ESPN+, subject to change. Offer valid for eligible subscribers, devices, and billing partners. Access content from each service separately. Location data may be required to watch certain content. For detailed information on billing and cancelation, please visit the Hulu Help Center (<a href=\"https://help.hulu.com/s/article/hulu-disney-espn-bundle\" target=\"_blank\">https://help.hulu.com/s/article/hulu-disney-espn-bundle</a>).",
+						"modalTitle": "",
+						"id": "live-tv-legal-modal",
+						"metrics": {}
+					},
+					{
+						"type": "modal",
+						"body": "Due to streaming rights, a few shows with an ad break before and after. <a href=\"https://help.hulu.com/en-us/included-in-no-commercials-plan\" target=\"_blank\">Which shows?</a>",
+						"modalTitle": "",
+						"id": "exception-shows-modal",
+						"metrics": {}
+					},
+					{
+						"type": "html_module",
+						"html_code": "<style>\n    .value-prop-disclaimer {\n        color: #586174;\n        font-size: 10px;\n        font-weight: normal;\n        line-height: 16px;\n    }\n    .Masthead__legal.section-disclaimer .button-link {\n        color: white;\n    }\n</style>",
+						"metrics": {}
+					},
+					{
+						"type": "exp_plan_comparison_chart_with_toggle",
+						"headline": "Select Your Plan",
+						"description": "No hidden fees, equipment rentals, or installation appointments.<br /><b>Switch plans or cancel anytime.**</b>",
+						"addonsHeadline": "Available Add-ons",
+						"addonsDescription": "Add-ons available at an additional cost.<br />Add them up after you sign up for Hulu.",
+						"isDark": false,
+						"bundle": {
+							"headline": "Bundle ",
+							"description": "Includes Hulu (plan of your choice), Disney+, and ESPN+.",
+							"leftHeadline": "BASE PLANS",
+							"rightHeadline": "BUNDLE / SAVE",
+							"modal": {}
+						},
+						"bundlePlans": [
+							{
+								"slug": "trio-basic",
+								"headline": "Disney Bundle Trio Basic",
+								"eyebrow": "",
+								"disclaimer": {
+									"id": null,
+									"richText": "",
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"ctaText": "$12.99 / MONTH",
+								"mobileCtaText": "$12.99 / mo.",
+								"ctaAction": "/signup",
+								"badge": "",
+								"ctaBtnStyle": "none",
+								"program": "hulu-disney-espn-bundle-offer"
+							},
+							{
+								"slug": "trio-premium",
+								"headline": "Disney Bundle Trio Premium",
+								"eyebrow": "",
+								"disclaimer": {
+									"id": null,
+									"richText": "",
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"ctaText": "$19.99 / MONTH",
+								"mobileCtaText": "$19.99 / mo.",
+								"ctaAction": "/signup",
+								"badge": "",
+								"ctaBtnStyle": "none",
+								"program": "disney-bundle-hulu-no-ads"
+							},
+							{
+								"slug": "live-tv",
+								"headline": "Hulu + Live TV",
+								"eyebrow": "",
+								"disclaimer": {
+									"id": null,
+									"richText": "",
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"ctaText": "$69.99 / MONTH",
+								"mobileCtaText": "$69.99 / mo.",
+								"ctaAction": "/signup/go/live",
+								"badge": "",
+								"ctaBtnStyle": "black",
+								"program": ""
+							}
+						],
+						"plans": [
+							{
+								"slug": "hulu",
+								"headline": "Hulu (With Ads)",
+								"eyebrow": "30 DAY FREE TRIAL",
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"ctaText": "$7.99 / MONTH",
+								"mobileCtaText": "$7.99/mo.",
+								"ctaAction": "/signup/go/sash",
+								"badge": "MOST POPULAR",
+								"ctaBtnStyle": "black",
+								"program": ""
+							},
+							{
+								"slug": "no-ad",
+								"headline": "Hulu (No Ads)",
+								"eyebrow": "30 DAY FREE TRIAL",
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"ctaText": "$14.99 / month",
+								"mobileCtaText": "$14.99 / mo.",
+								"ctaAction": "/signup/go/noah",
+								"ctaBtnStyle": "black",
+								"program": ""
+							}
+						],
+						"pricingRows": [
+							{
+								"slug": "monthly-pricing-row",
+								"headline": "Monthly price",
+								"bundleHeadline": "Monthly price. Save up to $15.98/mo.*",
+								"prices": [
+									{
+										"text": "$7.99/mo.",
+										"bundle": {
+											"originalPriceText": "$25.97/mo.",
+											"discountedPriceText": "$12.99/mo.*"
+										}
+									},
+									{
+										"text": "$14.99/mo.",
+										"bundle": {
+											"originalPriceText": "$35.97/mo.",
+											"discountedPriceText": "$19.99/mo.*"
+										}
+									},
+									{
+										"bundle": {
+											"originalPriceText": "",
+											"discountedPriceText": "$69.99/mo."
+										}
+									}
+								]
+							}
+						],
+						"bundleFeatures": [
+							{
+								"slug": "subscriptions-included",
+								"headline": "Subscriptions included in each plan",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": "",
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": ""
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": false,
+										"text": "Disney+ (With Ads), Hulu (With Ads), ESPN+ (With Ads)"
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": false,
+										"text": "Disney+ (No Ads), Hulu (No Ads), ESPN+ (With Ads)"
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": false,
+										"text": "Hulu (With Ads) + Live TV, Disney+ (With Ads), ESPN+ (With Ads)"
+									}
+								]
+							},
+							{
+								"slug": "bundle-streaming-library",
+								"headline": "Hulu Streaming library with tons of episodes and movies",
+								"description": {
+									"richText": "Watch full seasons of exclusively streaming series, classic favorites, Hulu Originals, hit movies, current episodes, kids shows, and tons more. <br/><br/>Watch on 2 different screens at the same time.",
+									"modalId": "bundle-streaming-library-modal"
+								},
+								"disclaimer": {
+									"id": "",
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": ""
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": true
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": true
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "bundle-episodes-air",
+								"headline": "Most new episodes the day after they air†",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": "episodes-air-disclaimer",
+									"richText": "†For current-season shows in the streaming library only",
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": true
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": true
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "bundle-hulu-originals",
+								"headline": "Access to award-winning Hulu Originals",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": true
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": true
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "bundle-devices",
+								"headline": "Watch on your favorite devices, including TV, laptop, phone, or tablet",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": true
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": true
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "bundle-download-hulu",
+								"headline": "Download and watch on Hulu",
+								"description": {
+									"richText": "Download titles to your supported device for on-the-go-streaming. Save your data and watch offline. <br/><br/><div style=\"font-size: 12px; line-height: 14px;\"><i>Select content available for download.</i></div>",
+									"modalId": "bundle-download-modal"
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": "",
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": false
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": true
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": false
+									}
+								]
+							},
+							{
+								"slug": "bundle-bundle-live-tv",
+								"headline": "Live TV with 85+ top channels. No cable required.",
+								"description": {
+									"richText": "- Live sports including the NCAA, NBA, NHL, NFL, the English Premier League, and more.<br/><br/>- Breaking news on CNN, Fox News, and MSNBC, with local news channels in many cities.<br/><br/>- Live entertainment on ABC, CBS, FOX, NBC and more, including local channels and events like the Oscars®.",
+									"modalId": "bundle-live-tv-modal"
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": "",
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": false
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": false
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "bundle-live-tv-guide",
+								"headline": "Live TV guide to navigate channels",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": "",
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": false
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": false
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "bundle-cloud-dvr",
+								"headline": "Record Live TV with Unlimited DVR",
+								"description": {
+									"richText": "Store live TV recordings for up to nine months and fast-forward through your DVR content.<br/><br/><div style=\"font-size: 12px; line-height: 14px;\"><i>Unlimited DVR recording is not available for on-demand shows.</i></div>",
+									"modalId": "bundle-cloud-dvr-modal"
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": "",
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": false
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": false
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": true
+									}
+								]
+							}
+						],
+						"features": [
+							{
+								"slug": "streaming-library",
+								"headline": "Streaming Library with tons of TV episodes and movies",
+								"description": {
+									"richText": "Watch full seasons of exclusively streaming series, classic favorites, Hulu Originals, hit movies, current episodes, kids shows, and tons more.",
+									"modalId": "streaming-library-description"
+								},
+								"disclaimer": {
+									"id": "",
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": ""
+								},
+								"plans": [
+									{
+										"slug": "hulu",
+										"isApplicable": true
+									},
+									{
+										"slug": "no-ad",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "episodes-air",
+								"headline": "Most new episodes the day after they air†",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": "episodes-air-disclaimer",
+									"richText": "†For current-season shows in the streaming library only",
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "hulu",
+										"isApplicable": true
+									},
+									{
+										"slug": "no-ad",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "hulu-originals",
+								"headline": "Access to award-winning Hulu Originals",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "hulu",
+										"isApplicable": true
+									},
+									{
+										"slug": "no-ad",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "devices",
+								"headline": "Watch on your favorite devices, including TV, laptop, phone, or tablet",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "hulu",
+										"isApplicable": true
+									},
+									{
+										"slug": "no-ad",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "user-profiles",
+								"headline": "Up to 6 user profiles",
+								"description": {
+									"richText": "Now up to six members of your household can have separate profiles so that favorites and recommendations are unique to each viewer.",
+									"modalId": "user-profiles-modal"
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "hulu",
+										"isApplicable": true
+									},
+									{
+										"slug": "no-ad",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "different-screens",
+								"headline": "Watch on 2 different screens at the same time",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "hulu",
+										"isApplicable": true
+									},
+									{
+										"slug": "no-ad",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "no-ads",
+								"headline": "No ads in streaming library",
+								"description": {
+									"richText": "Stream our library of shows and movies without ad interruptions. <br/><br/><div style=\"font-size: 12px; line-height: 14px;\"><i>Due to streaming rights, a few shows are not included in the Hulu (No Ads) plan and will instead play interruption-free with a short ad break before and after each episode. Visit the Hulu Help Center for a list of shows.<br/>Hulu + Live TV plan: Switch to this plan after sign-up to get ad-free experience of Hulu’s streaming library only; live and VOD content available through Live TV plan plays with ads. No free trial available.</i></div>",
+									"modalId": "no-ads-modal"
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": "",
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "hulu",
+										"isApplicable": false
+									},
+									{
+										"slug": "no-ad",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "download-and-watch",
+								"headline": "Download and watch",
+								"description": {
+									"richText": "Download titles to your supported device for on-the-go-streaming. Save your data and watch offline.<br/><br/><div style=\"font-size: 12px; line-height: 14px;\"><i>Select content available for download.</i></div>",
+									"modalId": "download-and-watch-modal"
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": "",
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "hulu",
+										"isApplicable": false
+									},
+									{
+										"slug": "no-ad",
+										"isApplicable": true
+									}
+								]
+							}
+						],
+						"bundleFeatureDisclaimers": [
+							{
+								"richText": "*Savings compared to regular monthly price of each service. ",
+								"modalLinkText": "Terms apply.",
+								"modalContent": "U.S. residents, 18+ only. Access content from each service separately. Location data required to watch certain content. Offer valid for eligible subscribers only. Subject to <a href=\"https://www.hulu.com/terms\">Hulu Subscriber Agreement</a>. <br><br> For detailed information on billing and cancelation, please visit the Hulu Help Center (<a href=\"https://help.hulu.com/s/article/hulu-disney-espn-bundle\">https://help.hulu.com/s/article/hulu-disney-espn-bundle</a>). © 2022 Disney and its related entities."
+							},
+							{
+								"richText": "**Switches from Live TV to Hulu take effect as of the next billing cycle",
+								"modalLinkText": "",
+								"modalContent": null
+							},
+							{
+								"richText": "†For current-season shows in the streaming library only",
+								"modalLinkText": "",
+								"modalContent": null
+							},
+							{
+								"richText": "",
+								"modalLinkText": "",
+								"modalContent": null
+							},
+							{
+								"richText": "",
+								"modalLinkText": "",
+								"modalContent": null
+							}
+						],
+						"featureDisclaimers": [
+							{
+								"richText": "†For current-season shows in the streaming library only",
+								"modalLinkText": "",
+								"modalContent": null
+							},
+							{
+								"richText": "**Switches from Live TV to Hulu take effect as of the next billing cycle",
+								"modalLinkText": "",
+								"modalContent": null
+							}
+						],
+						"bundleAddons": [
+							{
+								"slug": "max",
+								"headline": "Max",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": true
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": true
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "cinemax",
+								"headline": "CINEMAX®",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": true
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": true
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "showtime",
+								"headline": "SHOWTIME®",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": true
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": true
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "starz",
+								"headline": "STARZ®",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": true
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": true
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "unlimited-screen",
+								"headline": "Unlimited Screens",
+								"description": {
+									"richText": "For everyone in the home.<br/><br/>• Upgrade to watch on unlimited screens at home<br/>• Plus, enjoy 3 screens when you’re on the go<br/><br/><div style=\"font-size: 12px; line-height: 14px;\"><i>Premium network restrictions apply.</i></div>",
+									"modalId": "unlimited-screen-modal"
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": false
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": false
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "entertainment-add-on",
+								"headline": "Entertainment Add-on",
+								"description": {
+									"richText": "Stay current with additional news, entertainment, and lifestyle programming from American Heroes Channel, BET Her, CNBC World, Cooking Channel, Crime + Investigation, Destination America, Discovery Family, Discovery Life, Magnolia Network, Military History Channel, MTV2, MTV Classic, Nick Toons, Science, and Teen Nick.",
+									"modalId": "entertainment-modal"
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": false
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": false
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "espanol-add-on",
+								"headline": "Español Add-on",
+								"description": {
+									"richText": "Enjoy a collection of popular favorites in Spanish – CNN en Español, Discovery en Español, Discovery Familia, ESPN Deportes, History Channel en Español, and Universo.",
+									"modalId": "espanol-modal"
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": false
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": false
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "sports-add-on",
+								"headline": "Sports Add-on",
+								"description": {
+									"richText": "Stream every touchdown from every game, every Sunday during the NFL regular season with NFL RedZone, along with hundreds of hours of live sports –motorsports (MAVTV), horse racing (FanDuel TV/FanDuel Racing) to hunting and fishing (Outdoor Channel, Sportsman Channel).",
+									"modalId": "sportsaddon-modal"
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "trio-basic",
+										"isApplicable": false
+									},
+									{
+										"slug": "trio-premium",
+										"isApplicable": false
+									},
+									{
+										"slug": "live-tv",
+										"isApplicable": true
+									}
+								]
+							}
+						],
+						"addons": [
+							{
+								"slug": "max",
+								"headline": "Max",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "hulu",
+										"isApplicable": true
+									},
+									{
+										"slug": "no-ad",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "cinemax",
+								"headline": "CINEMAX®",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "hulu",
+										"isApplicable": true
+									},
+									{
+										"slug": "no-ad",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "showtime",
+								"headline": "SHOWTIME®",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "hulu",
+										"isApplicable": true
+									},
+									{
+										"slug": "no-ad",
+										"isApplicable": true
+									}
+								]
+							},
+							{
+								"slug": "starz",
+								"headline": "STARZ®",
+								"description": {
+									"richText": null,
+									"modalId": ""
+								},
+								"disclaimer": {
+									"id": null,
+									"richText": null,
+									"modalLinkText": "",
+									"modalContent": null
+								},
+								"plans": [
+									{
+										"slug": "hulu",
+										"isApplicable": true
+									},
+									{
+										"slug": "no-ad",
+										"isApplicable": true
+									}
+								]
+							}
+						],
+						"bundleAddonDisclaimers": [],
+						"addonDisclaimers": [],
+						"metrics": {}
+					},
+					{
+						"type": "html_module",
+						"html_code": "<style>\n    .is-dark .plans-container__features-container__disclaimer > a {\n        color: white;\n        text-decoration: underline;\n    }\n    .plans-container__features-container__disclaimer > a {\n        color: #272c34;\n        text-decoration: underline;\n    }\n  .exp-plans-container .plan-head__card-title {\n    padding-left: 0px;\n    padding-right: 0px;\n  }\n  .exp-plans-container .plan-head__card.plan-head__card-2.col-xs-4.plan-head__card--short .plan-head__card-content .plan-head__card-title {\n    padding-top: 18px;\n  }\n  .exp-plans-container .plan-head__card-eyebrow-image > img {\n    max-height: 20px;\n  }\n  .exp-plans-container .plan-feature__bullet_text {\n      font-size: 14px;\n  }\n  @media (min-width: 540px) {\n    .exp-plans-container .plan-head__card-title {\n      padding-left: 20px;\n      padding-right: 20px;\n    }\n    .exp-plans-container .plan-head__card.plan-head__card-2.col-xs-4.plan-head__card--short .plan-head__card-content .plan-head__card-title {\n      padding-top: 18px;\n    }\n    .exp-plans-container .plan-head__card-eyebrow-image > img {\n      max-height: 30px;\n    }\n  }\n\n  @media (min-width: 768px) {\n    .exp-plans-container .plan-head__card-title {\n      padding-left: 0px;\n      padding-right: 0px;\n    }\n    .exp-plans-container .plan-head__card.plan-head__card-2.col-xs-4.plan-head__card--short .plan-head__card-content .plan-head__card-title {\n      padding-top: 0px;\n    }\n    .exp-plans-container .plan-head__card-eyebrow-image > img {\n      max-height: 30px;\n    }\n  }\n  @media (min-width: 1024px) {\n    .exp-plans-container .plan-head-column-for-new-toggle.plan-head-column--short {\n        margin-top: -27px;\n    }\n    .exp-plans-container .plan-head-column-for-new-toggle.plan-head-column--short .bundle-header-with-new-toggle {\n        margin-top: 27px;\n    }\n    /* .is-dark .col-xs-4.plan-feature__check-0, .is-dark .plan-head__card-0.plan-head__card--short {\n        background-color: transparent;\n    } */\n\n    /* .exp-plans-container .plan-head__card.plan-head__card-0.col-xs-4.plan-head__card--short, .plan-head__card.plan-head__card-1.col-xs-4.plan-head__card--short,\n        .plan-head__card.plan-head__card-2.col-xs-4.plan-head__card--short {\n            margin-top: 27px;\n    } */\n\n    .exp-plans-container .plan-head__card-title {\n      padding-left: 15px;\n      padding-right: 15px;\n    }\n    .exp-plans-container .plan-head__card.plan-head__card-2.col-xs-4.plan-head__card--short .plan-head__card-content .plan-head__card-title {\n      padding-top: 24px;\n    }\n    .exp-plans-container .plan-head__card-eyebrow-image > img {\n      max-height: 30px;\n    }\n    .exp-plans-container .plan-head__card-title > span {\n      font-size: 18px;\n    }\n  }\n  @media (min-width: 1600px) {\n    .exp-plans-container .plan-head__card-title {\n      padding-left: 30px;\n      padding-right: 30px;\n    }\n    .exp-plans-container .plan-head__card.plan-head__card-2.col-xs-4.plan-head__card--short .plan-head__card-content .plan-head__card-title {\n      padding-top: 24px;\n    }\n    .exp-plans-container .plan-head__card-eyebrow-image > img {\n      max-height: 30px;\n    }\n    .exp-plans-container .plan-head__card-title > span {\n      font-size: 18px;\n    }\n  }\n</style>",
+						"metrics": {}
+					},
+					{
+						"type": "html_module",
+						"html_code": "<script type=\"text/javascript\">\n    const SWITCH_ID = 'toggle-switch';\n    const IMAGE_CLASS_NAME = 'plan-head__card-eyebrow-image';\n    const DARK_IMAGE = '/static/hitch/static/logos/bundles-dark.svg';\n    const WHITE_IMAGE = '/static/hitch/static/logos/bundles.svg';\n    const RENDER_TIME = 10;\n\n    const switchElement = document.getElementById(SWITCH_ID).parentNode.parentNode;\n\n    switchElement.addEventListener('load', () => {\n    setTimeout(() => {\n        changeImage();\n    }, RENDER_TIME);\n    });\n\n    switchElement.addEventListener('click', () => {\n    setTimeout(() => {\n        changeImage();\n    }, RENDER_TIME);\n    });\n\n    const changeImage = () => {\n    const imageContainers = document.getElementsByClassName(IMAGE_CLASS_NAME);\n    const compChartElement = document.getElementById('plans');\n    const isDark = compChartElement.classList.contains('is-dark');\n\n    Array.from(imageContainers).forEach((container) => {\n        container.children[0].src = isDark ? DARK_IMAGE : WHITE_IMAGE;\n    });\n    };\n</script>\n",
+						"metrics": {}
+					},
+					{
+						"type": "modal",
+						"body": "<strong>What's Included in The Disney Bundle?</strong>\n<br>\n<br>\n<img src=\"/static/hitch/static/icons/Pricing_Checkmark_black.svg\" role=\"presentation\"> Subscriptions to Disney+, ESPN+, and Hulu for a discounted price. Available with Hulu (With Ads) for $12.99/month or with Hulu (No Ads) for $19.99/month.\n<br>\n<br>\n<img src=\"/static/hitch/static/icons/Pricing_Checkmark_black.svg\" role=\"presentation\"> Save over $11/month compared to the current regular monthly price of each service when purchased separately.\n<br>\n<br>\n<img src=\"/static/hitch/static/icons/Pricing_Checkmark_black.svg\" role=\"presentation\"> Enjoy all your favorite shows, movies, sports, and more using the Disney+, Hulu, and ESPN+ apps (or sites, for those on a browser). Download each app separately to access each service.\n<br>\n<br>\n<img src=\"/static/hitch/static/icons/Pricing_Checkmark_black.svg\" role=\"presentation\"> Cancel anytime.\n<br>\n<br>\nSavings compared to current regular monthly price for each service.\n<br><br>\n<div class=\"value-prop-disclaimer\">&nbsp;</div>",
+						"modalTitle": "",
+						"id": "bundle_details",
+						"metrics": {}
+					},
+					{
+						"type": "html_module",
+						"html_code": "<style type=\"text/css\">\n @media screen and (max-width: 768px) {\n  .DetailEntityMetadata {\n    display: none;\n  }\n  .DetailEntityMasthead__disclaimer {\n    display:block;\n  }\n}\n</style>",
+						"metrics": {}
+					}
+				],
+				"detailEntity": {
+					"type": "series",
+					"id": "9c91ffa3-dc20-48bf-8bc5-692e37c76d88",
+					"name": "Attack on Titan",
+					"description": "From the director of Death Note comes Attack on Titan. Many years ago, humanity was forced to retreat behind the towering walls of a fortified city to escape the massive, man-eating Titans that roamed the land outside their fortress. This is their story.",
+					"network": "Crunchyroll",
+					"premiereDate": "2013-04-07T00:00:00Z",
+					"artwork": {
+						"horizontalProgramTile": {
+							"path": "https://img3.hulu.com/user/v3/artwork/9c91ffa3-dc20-48bf-8bc5-692e37c76d88?base_image_bucket_name=image_manager&base_image=f8b052de-8f1e-4f1a-bf58-1390f3598000"
+						},
+						"verticalHero": {
+							"path": "https://img3.hulu.com/user/v3/artwork/9c91ffa3-dc20-48bf-8bc5-692e37c76d88?base_image_bucket_name=image_manager&base_image=0d6eb2f9-891d-4076-8ce9-22a297b9f2ca"
+						}
+					},
+					"href": "https://www.hulu.com/series/attack-on-titan-9c91ffa3-dc20-48bf-8bc5-692e37c76d88",
+					"requireLivePackage": false,
+					"redirectTo": null,
+					"latestSeason": {
+						"season": "4",
+						"previousSeason": "3"
+					},
+					"credits": [
+						{
+							"prefix": "Starring:",
+							"seoSchemaProp": "actor",
+							"items": [
+								"Yûki Kaji",
+								"Yui Ishikawa",
+								"Marina Inoue",
+								"Kisho Taniyama",
+								"Yu Shimamura"
+							],
+							"truncatedItems": [
+								"Yûki Kaji",
+								"Yui Ishikawa",
+								"Marina Inoue"
+							]
+						}
+					],
+					"latestTrailer": {
+						"title": "Attack on Titan Final Season Part 2 - PV 2",
+						"eabId": "EAB::a2ee9bf4-37c5-4720-801c-ed5d88ea11b3::61703763::176894325",
+						"duration": "PT100S",
+						"uploadDate": "2022-04-20T19:00:00Z"
+					}
+				},
+				"metrics": {
+					"collectionCount": 4
+				},
+				"options": {
+					"enableBrand": false,
+					"enableHotjar": false,
+					"ctaMobileFlag": false,
+					"ctaAnonCopy": null,
+					"ctaAnonLink": null,
+					"ctaAllCopy": null,
+					"ctaAllLink": null,
+					"ctaSomeCopy": null,
+					"ctaSomeLink": null,
+					"ctaSomeNotToAddonCopy": null,
+					"ctaSomeNotToAddonLink": null,
+					"ctaSomeAndNotEnrolledCopy": null,
+					"ctaSomeAndNotEnrolledLink": null,
+					"ctaIneligibleCopy": null,
+					"ctaIneligibleLink": null,
+					"ctaInactiveCopy": null,
+					"ctaInactiveLink": null,
+					"ctaAppleCopy": null,
+					"ctaAppleLink": null,
+					"cartAbandonmentCopy": {
+						"planAndNameCopy": null,
+						"nameCopy": null,
+						"planCopy": null,
+						"defaultCopy": null,
+						"href": null
+					},
+					"disableFooter": null,
+					"displayTheme": null,
+					"pageType": "landing",
+					"allowSubscriberTraffic": false,
+					"shouldCheckForPrepaid": false,
+					"cohortCheck": false,
+					"checkProgramWindow": false,
+					"footer": null,
+					"contentOverrides": {
+						"overrideName": null,
+						"overrideDescription": null
+					}
+				},
+				"program": {
+					"partner": null,
+					"hiswitchPackages": null,
+					"type": null
+				},
+				"requireLivePackage": false,
+				"redirectTo": null,
+				"metatags": [
+					{
+						"value": "Watch Attack on Titan Streaming Online | Hulu (Free Trial)",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "title"
+					},
+					{
+						"value": "Start your free trial to watch Attack on Titan and other popular TV shows and movies including new releases, classics, Hulu Originals, and more. It’s all on Hulu.",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "description"
+					},
+					{
+						"value": "https://www.hulu.com/series/attack-on-titan-9c91ffa3-dc20-48bf-8bc5-692e37c76d88",
+						"valueName": "href",
+						"keyName": "rel",
+						"tag": "link",
+						"key": "canonical"
+					},
+					{
+						"value": "en-US",
+						"valueName": "content",
+						"keyName": "httpEquiv",
+						"tag": "meta",
+						"key": "content-language"
+					},
+					{
+						"value": "text/html; charset=UTF-8",
+						"valueName": "content",
+						"keyName": "httpEquiv",
+						"tag": "meta",
+						"key": "content-type"
+					},
+					{
+						"value": "ie=edge",
+						"valueName": "content",
+						"keyName": "httpEquiv",
+						"tag": "meta",
+						"key": "x-ua-compatible"
+					},
+					{
+						"value": "web-nonsub",
+						"valueName": "content",
+						"keyName": "property",
+						"tag": "meta",
+						"key": "cu_app"
+					},
+					{
+						"value": "Hulu",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "application-name"
+					},
+					{
+						"value": "40582213222",
+						"valueName": "content",
+						"keyName": "property",
+						"tag": "meta",
+						"key": "fb:app_id"
+					},
+					{
+						"value": "width",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "MobileOptimized"
+					},
+					{
+						"value": "true",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "HandheldFriendly"
+					},
+					{
+						"value": "width=device-width, initial-scale=1.0",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "viewport"
+					},
+					{
+						"value": "Hulu",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "application-name"
+					},
+					{
+						"value": "App",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "msApplication-ID"
+					},
+					{
+						"value": "/",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "msapplication-starturl"
+					},
+					{
+						"value": "#ffffff",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "msapplication-tilecolor"
+					},
+					{
+						"value": "/icon-win8-tile.png",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "msapplication-tileimage"
+					},
+					{
+						"value": "Start Hulu with Internet Explorer enhancements.",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "msapplication-tooltip"
+					},
+					{
+						"value": "HuluLLC.HuluPlus_fphbd361v8tya",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "msApplication-PackageFamilyName"
+					},
+					{
+						"value": "3",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "cmsversion"
+					},
+					{
+						"value": "summary",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "twitter:card"
+					},
+					{
+						"value": "Attack on Titan",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "twitter:title"
+					},
+					{
+						"value": "@Hulu",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "twitter:site"
+					},
+					{
+						"value": "From the director of Death Note comes Attack on Titan. Many years ago, humanity was forced to retreat behind the towering walls of a fortified city to escape the massive, man-eating Titans that roamed the land outside their fortress. This is their story.",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "twitter:description"
+					},
+					{
+						"value": "https://www.hulu.com/series/attack-on-titan-9c91ffa3-dc20-48bf-8bc5-692e37c76d88",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "twitter:url"
+					},
+					{
+						"value": "https://img3.hulu.com/user/v3/artwork/9c91ffa3-dc20-48bf-8bc5-692e37c76d88?base_image_bucket_name=image_manager&base_image=f8b052de-8f1e-4f1a-bf58-1390f3598000&size=1200x630&format=jpeg",
+						"valueName": "content",
+						"keyName": "name",
+						"tag": "meta",
+						"key": "twitter:image"
+					},
+					{
+						"value": "15033883",
+						"valueName": "content",
+						"keyName": "property",
+						"tag": "meta",
+						"key": "twitter:account_id"
+					},
+					{
+						"value": "https://img3.hulu.com/user/v3/artwork/9c91ffa3-dc20-48bf-8bc5-692e37c76d88?base_image_bucket_name=image_manager&base_image=f8b052de-8f1e-4f1a-bf58-1390f3598000&size=1200x630&format=jpeg",
+						"valueName": "content",
+						"keyName": "property",
+						"tag": "meta",
+						"key": "og:image"
+					},
+					{
+						"value": "From the director of Death Note comes Attack on Titan. Many years ago, humanity was forced to retreat behind the towering walls of a fortified city to escape the massive, man-eating Titans that roamed the land outside their fortress. This is their story.",
+						"valueName": "content",
+						"keyName": "property",
+						"tag": "meta",
+						"key": "og:description"
+					},
+					{
+						"value": "https://www.hulu.com/series/attack-on-titan-9c91ffa3-dc20-48bf-8bc5-692e37c76d88",
+						"valueName": "content",
+						"keyName": "property",
+						"tag": "meta",
+						"key": "og:url"
+					},
+					{
+						"value": "https://www.hulu.com/series/attack-on-titan-9c91ffa3-dc20-48bf-8bc5-692e37c76d88",
+						"valueName": "content",
+						"keyName": "property",
+						"tag": "meta",
+						"key": "og:title"
+					},
+					{
+						"value": "Hulu",
+						"valueName": "content",
+						"keyName": "property",
+						"tag": "meta",
+						"key": "og:site_name"
+					},
+					{
+						"value": "tv_show",
+						"valueName": "content",
+						"keyName": "property",
+						"tag": "meta",
+						"key": "og:type"
+					}
+				],
+				"title": "Watch Attack on Titan Streaming Online | Hulu (Free Trial)"
+			},
+			"geodata": {
+				"geodataOverrides": {}
+			},
+			"cartAbandonment": null,
+			"isSufReturningCustomer": false,
+			"useAnalytics": true,
+			"collectionCount": 4,
+			"isHiswitch": null,
+			"userIsLoggedIn": false,
+			"userIsSubscriber": false,
+			"user": {
+				"isHuluUser": false,
+				"isSubscriber": false,
+				"entitlementState": 0,
+				"entitlementFlag": true,
+				"isAppleBilled": false,
+				"name": ""
+			},
+			"config": {
+				"appComponentName": "hitch",
+				"gaEnv": "prod",
+				"tealiumEnv": "prod",
+				"disableRecaptcha": false,
+				"loginModalEnv": "prod",
+				"webLoginEnv": "prod",
+				"datadogRum": {
+					"applicationId": "33d824b1-a6ca-43c8-8ce7-2d38b47f4a5c",
+					"clientToken": "pub016bdb84b22c0458131a5fda78a720df"
+				},
+				"endpoints": {
+					"ballyhoo": "https://ballyhoo.prod.hulu.com",
+					"splat": "https://subplatform.prod.hulu.com",
+					"signup": "https://signup.hulu.com",
+					"hoth": "https://auth.hulu.com",
+					"hudis": "https://secure.hulu.com",
+					"site": "https://www.hulu.com",
+					"home": "https://home.hulu.com",
+					"hookup": "http://hookup-cannonball.prod.hulu.com",
+					"user_model": "http://user-model.prod.hulu.com",
+					"midgard": "http://midgard.prod.hulu.com"
+				},
+				"keys": {
+					"facebook_app_id": "40582213222"
+				},
+				"huluEnv": "production"
+			},
+			"isAppsFlyer": false
+		}
+	},
+	"page": "/BrowsePage",
+	"query": {
+		"entity": "series",
+		"id": "attack-on-titan-9c91ffa3-dc20-48bf-8bc5-692e37c76d88"
+	},
+	"buildId": "yNq7M_-ydIs4xwJ9Lddri",
+	"assetPrefix": "/static/hitch",
+	"runtimeConfig": {
+		"appComponentName": "hitch",
+		"gaEnv": "prod",
+		"tealiumEnv": "prod",
+		"disableRecaptcha": false,
+		"loginModalEnv": "prod",
+		"webLoginEnv": "prod",
+		"datadogRum": {
+			"applicationId": "33d824b1-a6ca-43c8-8ce7-2d38b47f4a5c",
+			"clientToken": "pub016bdb84b22c0458131a5fda78a720df"
+		},
+		"endpoints": {
+			"ballyhoo": "https://ballyhoo.prod.hulu.com",
+			"splat": "https://subplatform.prod.hulu.com",
+			"signup": "https://signup.hulu.com",
+			"hoth": "https://auth.hulu.com",
+			"hudis": "https://secure.hulu.com",
+			"site": "https://www.hulu.com",
+			"home": "https://home.hulu.com",
+			"hookup": "http://hookup-cannonball.prod.hulu.com",
+			"user_model": "http://user-model.prod.hulu.com",
+			"midgard": "http://midgard.prod.hulu.com"
+		},
+		"keys": {
+			"facebook_app_id": "40582213222"
+		},
+		"huluEnv": "production"
+	},
+	"isFallback": false,
+	"customServer": true,
+	"gip": true,
+	"appGip": true
+}

--- a/season_configs/spring_2023.yaml
+++ b/season_configs/spring_2023.yaml
@@ -1124,7 +1124,7 @@ streams:
   hidive: ''
   animelab|AnimeLab: ''
   vrv|VRV: 'https://vrv.co/series/GR751KNZY'
-  hulu|Hulu: 'https://www.hulu.com/series/attack-on-titan-9c91ffa3-dc20-48bf-8bc5-692e37c76d88'
+  hulu|Hulu: 'https://www.hulu.com/series/attack-on-titan-9c91ffa3-dc20-48bf-8bc5-692e37c76d88|28'
   disney|Disney: ''
   youtube: ''
   nyaa: ''

--- a/src/services/stream/hulu.py
+++ b/src/services/stream/hulu.py
@@ -1,0 +1,191 @@
+import json
+import logging
+import re
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Iterable
+
+from data.models import Episode, Stream, UnprocessedStream
+
+from .. import AbstractServiceHandler
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class HuluEpisode:
+	name: str = ""
+	date: datetime = datetime.utcnow()
+	season: int = 0
+	number: int = 0
+	series_name: str = ""
+
+
+class InvalidHuluException(Exception):
+	"""Generic exception raised when parsing the contents of a Hulu webpage."""
+
+
+class ServiceHandler(AbstractServiceHandler):
+	_show_url = "http://hulu.com/series/{id}"
+	_show_re = re.compile(r"hulu\.com\/series\/((?:\w+-?)+)", re.I)
+
+	def __init__(self) -> None:
+		super().__init__(key="hulu", name="Hulu", is_generic=False)
+
+	def get_all_episodes(self, stream: Stream, **kwargs: Any) -> Iterable[Episode]:
+		logger.info("Getting live episodes for Hulu/%s", stream.show_key)
+		url = self.get_stream_link(stream=stream)
+		if not url:
+			return []
+		response: str | None = self.request(url=url, **kwargs)
+		if not response:
+			logger.error("Cannot reach URL")
+			return []
+		try:
+			json_contents = _get_json_data(raw_html=response)
+			episodes_data = _get_episodes_data(json_contents)
+		except (
+			InvalidHuluException,
+			json.JSONDecodeError,
+			KeyError,
+			TypeError,
+			AttributeError,
+			StopIteration,
+		):
+			logger.error("Cannot extract malformed content")
+			return []
+		if not episodes_data:
+			logger.debug("  No episodes found")
+			return []
+		episodes = list(map(_process_episode, filter(_is_valid_episode, episodes_data)))
+		logger.debug("  %d episodes found, %d valid", len(episodes_data), len(episodes))
+		return episodes
+
+	def get_stream_link(self, stream: Stream) -> str | None:
+		if not stream.show_key:
+			logger.warning("Missing show key from stream %s", stream)
+			return None
+		return self._show_url.format(id=stream.show_key)
+
+	def extract_show_key(self, url: str) -> str | None:
+		match = self._show_re.search(url)
+		if match:
+			return match.group(1)
+		return None
+
+	def get_stream_info(self, stream: Stream, **kwargs: Any) -> Stream | None:
+		logger.info("Getting stream info for Hulu/%s", stream.show_key)
+		url = self.get_stream_link(stream)
+		if not url:
+			logger.error("Cannot get URL")
+			return None
+		response: str | None = self.request(url=url, **kwargs)
+		if not response:
+			logger.error("Cannot reach URL")
+			return None
+		try:
+			json_contents = _get_json_data(raw_html=response)
+			stream_name = _extract_series_name_from_json(json_contents)
+		except (
+			InvalidHuluException,
+			json.JSONDecodeError,
+			KeyError,
+			TypeError,
+			AttributeError,
+		):
+			logger.error("Cannot extract malformed content")
+			return None
+		stream.name = stream_name
+		return stream
+
+	def get_seasonal_streams(self, **kwargs: Any) -> list[UnprocessedStream]:
+		# Not implemented
+		return []
+
+
+def _get_json_data(raw_html: str) -> Any:
+	pattern = r"<script id=\"__NEXT_DATA__\" type=\"application\/json\">(.+?)<\/script>"
+	contents = re.findall(pattern, raw_html)
+	if not contents:
+		raise InvalidHuluException
+	if len(contents) > 1:
+		logger.warning(
+			"Multiple matches found, may have unexpected results. The first match will be used."
+		)
+	contents_json = json.loads(contents[0])
+	return contents_json
+
+
+def _extract_series_name_from_json(json_contents: Any) -> str:
+	if json_contents["props"]["pageProps"]["layout"]["locale"].lower() != "en-us":
+		logger.warning("  Language not en-us")
+	components = json_contents["props"]["pageProps"]["layout"]["components"]
+	head = next((c for c in components if c["type"] == "detailentity_masthead"), None)
+	if not head:
+		raise InvalidHuluException
+	return head["title"]
+
+
+def _get_episodes_data(contents_json: Any) -> list[HuluEpisode]:
+	page = contents_json["props"]["pageProps"]
+	if page["layout"]["locale"].lower() != "en-us":
+		logger.warning("Unexpected language detected, may have unexpected results")
+	components = page["layout"]["components"]
+	collection = next((c for c in components if c["type"] == "collection_tabs"))
+	episode_container: list[dict[str, str]] = []
+	episode_container = next(
+		(
+			tab["model"]["collection"]["items"]
+			for tab in collection["tabs"]
+			if tab["title"] == "Episodes"
+		),
+		episode_container,
+	)
+	if not episode_container:
+		raise InvalidHuluException
+	episodes = list(
+		filter(
+			None,
+			[_format_episode_from_json(episode) for episode in episode_container],
+		)
+	)
+	return episodes
+
+
+def _format_episode_from_json(episode_json: dict[str, str]) -> HuluEpisode | None:
+	name = episode_json["name"]
+	date = episode_json["premiereDate"]
+	season = int(episode_json["season"])
+	number = int(episode_json["number"])
+	series_name = episode_json["seriesName"]
+	if name.lower().startswith("(dub)"):
+		return None
+	if name.lower().startswith("(sub)"):
+		name = name[6:]
+	formatted_episode = HuluEpisode(
+		name=name,
+		date=datetime.fromisoformat(date).replace(tzinfo=None),
+		season=season,
+		number=number,
+		series_name=series_name,
+	)
+	return formatted_episode
+
+
+_time_adjustments = {
+	"Tengoku Daimakyo": timedelta(hours=1),  # 12pm UTC -> 1pm UTC
+}
+
+
+def _is_valid_episode(episode: HuluEpisode) -> bool:
+	date_diff = datetime.utcnow() - (
+		episode.date + _time_adjustments.get(episode.series_name, timedelta(0))
+	)
+	if date_diff >= timedelta(days=2):
+		logger.debug("  Episode S%dE%d too old", episode.season, episode.number)
+		return False
+	return True
+
+
+def _process_episode(episode: HuluEpisode) -> Episode:
+	return Episode(number=episode.number, name=episode.name, link="", date=episode.date)


### PR DESCRIPTION
Add ``hulu.py``, working as similarly as possible to other existing services (CR/HIDIVE), I figured this could be needed as we have an exclusive series this season and it may happen again in the future.
(Technically it's also on D+, but I have no idea how to get data from that one)

Include some explanation of how the relevant data is scraped from the show's page, as well as two examples from Heavenly Delusions and Attack on Titan.

Two things observed based on the two series:
* Episode times may be inaccurate: Heavenly Delusions releases at 1pm UTC (according to livechart.me and some Reddit comments) while its webpage lists it at 12pm UTC. Regardless of whether this is information is correct, there is a dictionary ``series name -> timedelta`` put in place for such instances, defaulted to 0.
* Episode numbering between seasons may be wonky. An appropriate ``remote_offset`` probably takes care of it well enough, combined with the release date filtering out previous seasons.