### PR TITLE
Add date check for HIDIVE

### DIFF
--- a/src/services/stream/hidive.py
+++ b/src/services/stream/hidive.py
@@ -1,33 +1,54 @@
-from logging import debug, info, warning, error, exception
 import re
 from datetime import datetime, timedelta
+from logging import debug, error, exception, info, warning
+from typing import Any
+
+from bs4 import BeautifulSoup, Tag
+
+from data.models import Episode, Stream, UnprocessedStream
 
 from .. import AbstractServiceHandler
-from data.models import Episode, UnprocessedStream
+
 
 class ServiceHandler(AbstractServiceHandler):
     _show_url = "https://www.hidive.com/tv/{id}"
     _show_re = re.compile("hidive.com/tv/([\w-]+)", re.I)
+    _date_re = re.compile(r"Premiere: (\d+)/(\d+)/(\d+)")
 
     def __init__(self):
         super().__init__("hidive", "HIDIVE", False)
 
     # Episode finding
 
-    def get_all_episodes(self, stream, **kwargs):
+    def get_all_episodes(self, stream: Stream, **kwargs: Any) -> list[Episode]:
         info(f"Getting live episodes for HiDive/{stream.show_key}")
+        episodes: list[Episode] = []
         episode_datas = self._get_feed_episodes(stream.show_key, **kwargs)
 
-        # Check episode validity and digest
-        episodes = []
-        for episode_data in episode_datas:
-            if _is_valid_episode(episode_data, stream.show_key):
-                try:
-                    episode = _digest_episode(episode_data)
-                    if episode is not None:
-                        episodes.append(episode)
-                except:
-                    exception(f"Problem digesting episode for HiDive/{stream.show_key}")
+        # HIDIVE does not include episode date in the show's page
+        # Pre-process the data to obtain all the other information
+        # Sort the episodes by descending number
+        # Check individual episode dates, stop at the first invalid episode
+        # (Assumption: all new episodes have increasing numbers,
+        # to reduce the number of requests to make)
+        try:
+            episode_candidates = sorted(
+                list(filter(None, map(_digest_episode, episode_datas))),
+                key=lambda e: e.number,
+                reverse=True,
+            )
+        except Exception:
+            exception("Problem digesting episode for HiDive/%s", stream.show_key)
+            return episodes
+
+        for episode in episode_candidates:
+            try:
+                episode = self._to_valid_episode(episode, stream.show_key, **kwargs)
+                if not episode:
+                    break
+                episodes.append(episode)
+            except Exception:
+                exception("Problem validating episode for HiDive/%s", stream.show_key)
 
         if len(episode_datas) > 0:
             debug(f"  {len(episode_datas)} episodes found, {len(episodes)} valid")
@@ -35,7 +56,7 @@ class ServiceHandler(AbstractServiceHandler):
             debug("  No episode found")
         return episodes
 
-    def _get_feed_episodes(self, show_key, **kwargs):
+    def _get_feed_episodes(self, show_key: str, **kwargs: Any) -> list[Tag]:
         info(f"Getting episodes for HiDive/{show_key}")
 
         url = self._get_feed_url(show_key)
@@ -50,6 +71,25 @@ class ServiceHandler(AbstractServiceHandler):
         sections = response.find_all("div", {"data-section": "episodes"})
         #return [section.a['data-playurl'] for section in sections if section.a]
         return sections
+
+
+    def _to_valid_episode(self, episode: Episode, show_key: str, **kwargs: Any) -> Episode | None:
+        response: BeautifulSoup = self.request(episode.link, html=True, **kwargs)
+        if not (response and response.h2):
+            warning("Invalid episode link for show %s/%s", self.key, show_key)
+            return episode
+        match = self._date_re.search(response.h2.text or "")
+        if not match:
+            warning("Date not found")
+            return episode
+        month, day, year = map(int, match.groups()) # MM/DD/YY date format
+        episode_day = datetime(day=day,month=month,year=year)
+        date_diff = datetime.utcnow() - episode_day
+        if date_diff >= timedelta(days=2):
+            debug("  Episode too old")
+            return None
+        episode.date = episode_day
+        return episode
 
 
     @classmethod
@@ -96,43 +136,35 @@ _episode_re_alter = re.compile("(?:https://www.hidive.com)?/stream/[\w-]+/\d{4}\
 _episode_name_correct = re.compile("(?:E\d+|Shorts) ?\| ?(.*)")
 _episode_name_invalid = re.compile(".*coming soon.*", re.I)
 
-def _is_valid_episode(episode_data, show_key):
-    # Possibly other cases to watch ?
-    if episode_data.a is None:
-        return False
-    #return re.match(_episode_re.format(id=show_key), episode_data) is not None
-
-    return True
-
-def _digest_episode(feed_episode):
+def _digest_episode(feed_episode: Tag) -> Episode | None:
     debug("Digesting episode")
-
-    episode_link = feed_episode.a['href']
+    if not feed_episode.a:
+        return None
+    link = f"https://www.hidive.com{feed_episode.a['href']}"
 
     # Get data
-    num_match = _episode_re.match(episode_link)
-    num_match_alter = _episode_re_alter.match(episode_link)
+    num_match = _episode_re.match(link)
+    num_match_alter = _episode_re_alter.match(link)
     if num_match:
         num = int(num_match.group(1))
     elif num_match_alter:
         warning("Using alternate episode key format")
         num = int(num_match_alter.group(1))
     else:
-        warning(f"Unknown episode number format in {episode_link}")
+        warning("Unknown episode number format in %s", link)
         return None
     if num <= 0:
         return None
 
-    name = feed_episode.h2.text
+    name = feed_episode.h2.text if feed_episode.h2 else ""
     name_match = _episode_name_correct.match(name)
     if name_match:
-        debug(f"  Corrected title from {name}")
+        debug("  Corrected title from %s", name)
         name = name_match.group(1)
     if _episode_name_invalid.match(name):
-        warning(f"  Episode title not found")
-        name = None
+        warning("  Episode title not found")
+        name = ""
 
-    link = episode_link
-    date = datetime.utcnow() # Not included in stream !
+    date = datetime.utcnow() # Not included in stream page!
 
     return Episode(num, name, link, date)


### PR DESCRIPTION
The stream page does not have date information, but individual episode pages do.

* Get each episode's number and URL first
* Assume that newer episodes have increasing order to avoid requesting all episodes every time
* In descending episode order, check the individual episode for its date and update it
* Stop whenever an episode is too old, discard all the remaining episodes

[Example log for Spy Classroom](https://i.imgur.com/otTnGip.png)