### PR TITLE
Add sanity check for multiple new episodes

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -10,6 +10,7 @@ username =
 password = 
 oauth_key = 
 oauth_secret = 
+max_episodes = 5
 
 [service.mal]
 username = 

--- a/src/config.py
+++ b/src/config.py
@@ -20,6 +20,8 @@ class Config:
 		self.r_oauth_key = None
 		self.r_oauth_secret = None
 		
+		self.max_episodes = 5
+		
 		self.services = dict()
 		
 		self.new_show_types = list()
@@ -68,6 +70,7 @@ def from_file(file_path):
 		config.r_password = sec.get("password", None)
 		config.r_oauth_key = sec.get("oauth_key", None)
 		config.r_oauth_secret = sec.get("oauth_secret", None)
+		config.max_episodes = sec.getint("max_episodes", 5)
 	
 	if "options" in parsed:
 		sec = parsed["options"]

--- a/src/holo.py
+++ b/src/holo.py
@@ -86,6 +86,7 @@ if __name__ == "__main__":
 	parser.add_argument("-s", "--subreddit", dest="subreddit", nargs=1, default=None, help="set the subreddit on which to make posts")
 	parser.add_argument("-o", "--output", dest="output", nargs=1, default="db", help="set the output mode (db or yaml) if supported")
 	parser.add_argument("-L", "--log-dir", dest="log_dir", nargs=1, default=["logs"], help="set the log directory")
+	parser.add_argument("-e", "--max-episodes", dest="max_episodes", type=int, default=0, help="set the maximum number of threads to post at once for a single show")
 	parser.add_argument("-v", "--version", action="version", version="{} v{}, {}".format(name, version, description))
 	parser.add_argument("--debug", action="store_true", default=False)
 	parser.add_argument("extra", nargs="*")
@@ -107,6 +108,8 @@ if __name__ == "__main__":
 		c.database = args.db_name[0]
 	if args.subreddit is not None:
 		c.subreddit = args.subreddit[0]
+	if args.max_episodes:
+		c.max_episodes = args.max_episodes
 
 	# Start
 	use_log = args.no_input

--- a/src/module_find_episodes.py
+++ b/src/module_find_episodes.py
@@ -35,6 +35,16 @@ def main(config, db, **kwargs):
 					info("  Show/episode not found")
 					continue
 
+				ep_num = len({e.number for e in episodes})
+				if ep_num > config.max_episodes:
+					warning(
+						"Too many episodes (%s) found for show %s on service #%s",
+						ep_num,
+						show.name,
+						stream.service,
+					)
+					continue
+
 				for episode in sorted(episodes, key=lambda e: e.number):
 					if _process_new_episode(config, db, show, stream, episode):
 						has_new_episode.append(show)
@@ -68,6 +78,16 @@ def main(config, db, **kwargs):
 
 					if not episodes:
 						info("  No episode found")
+						continue
+
+					ep_num = len({e.number for e in episodes})
+					if ep_num > config.max_episodes:
+						warning(
+							"Too many episodes (%s) found for show %s on service #%s",
+							ep_num,
+							show.name,
+							stream.service,
+						)
 						continue
 
 					for episode in sorted(episodes, key=lambda e: e.number):


### PR DESCRIPTION
Add a max number of episode threads to post for a single show in one run. If the value is surpassed, don't post any thread for that show batch and log a warning instead.
The value can be set in the config file, and overridden with the ``-e`` option.

The check is done in the main function of the episode module, so it does not affect e.g. manual batch posting.

Resolve #136 