### PR TITLE
Change poll service

### DIFF
--- a/examples/strawpoll_poll_creation.py
+++ b/examples/strawpoll_poll_creation.py
@@ -1,0 +1,30 @@
+# Example of automated poll submission to strawpoll.ai
+# Last tested on 2023/10/07
+
+import re
+import requests
+
+URL = "https://strawpoll.ai/poll-maker/"
+DATA = (
+    '{{"address":"","token":"{token}","type":"0",'
+    '"questions":[{{"plurality":{{"isVoterOpts":false,"maxOpts":"10"}},'
+    '"approval":{{"type":"0","value":"1","lower":"1","upper":"1"}},'
+    '"range":{{"min":"1","max":"10"}},"integer":{{"min":"1","max":"10"}},'
+    '"rational":{{"min":"1.0","max":"10.0"}},"type":"0",'
+    '"title":"test question","opts":["answer 1","answer 2","answer 3"]}}],'
+    '"settings":{{"reddit":{{"link":"0","comment":"200","days":"3"}},'
+    '"limits":"3","isCaptcha":false,"isDeadline":false,"isHideResults":false,"deadline":null}}}}'
+)
+
+g = requests.get(URL, timeout=60)
+match = re.search(r"<input type=\"hidden\" id=\"pm-token\" value=\"(\w+)\">", g.text)
+assert match
+token = match.group(1)
+data = DATA.format(token=token)
+cookies = {"PHPSESSID": g.headers["set-cookie"].split(";")[0].split("=")[1]}
+p = requests.post(URL, data={"data": f"{data}"}, cookies=cookies, timeout=60)
+
+print(p.history)
+# History should be a list with a 302 response
+print(p.url)
+# Response URL should be https://strawpoll.ai/poll/vote/{poll_id}

--- a/src/module_find_episodes.py
+++ b/src/module_find_episodes.py
@@ -2,6 +2,7 @@ from logging import debug, info, warning, error
 from datetime import date, timedelta
 
 import services
+from data.database import DatabaseDatabase
 from data.models import Stream
 import reddit
 
@@ -248,7 +249,7 @@ def _gen_text_links(db, formats, show):
 
 	return "\n".join(link_texts) + '\n' + '\n'.join(link_texts_bottom)
 
-def _gen_text_discussions(db, formats, show, stream):
+def _gen_text_discussions(db: DatabaseDatabase, formats, show, stream):
 	episodes = db.get_episodes(show)
 	debug("Num previous episodes: {}".format(len(episodes)))
 	N_LINES = 13
@@ -260,8 +261,12 @@ def _gen_text_discussions(db, formats, show, stream):
 		table = []
 		for episode in episodes:
 			episode = stream.to_display_episode(episode)
-			poll_handler = services.get_default_poll_handler()
 			poll = db.get_poll(show, episode)
+			if poll:
+				poll_site = db.get_poll_site(id=poll.service_id)
+				poll_handler = services.get_poll_handler(poll_site=poll_site)
+			else:
+				poll_handler = services.get_default_poll_handler()
 			if poll is None:
 				score = None
 				poll_link = None
@@ -288,12 +293,12 @@ def _gen_text_aliases(db, formats, show):
 		return ""
 	return safe_format(formats["aliases"], aliases=", ".join(aliases))
 
-def _gen_text_poll(db, config, formats, show, episode):
-	handler = services.get_default_poll_handler()
+def _gen_text_poll(db: DatabaseDatabase, config, formats, show, episode):
 	title = config.post_poll_title.format(show = show.name, episode = episode.number)
 
 	poll = db.get_poll(show, episode)
 	if poll is None:
+		handler = services.get_default_poll_handler()
 		poll_id = handler.create_poll(title, headers = {'User-Agent': config.useragent}, submit=not config.debug)
 		if poll_id:
 			site = db.get_poll_site(key=handler.key)
@@ -301,6 +306,8 @@ def _gen_text_poll(db, config, formats, show, episode):
 			poll = db.get_poll(show, episode)
 
 	if poll is not None:
+		poll_site = db.get_poll_site(id=poll.service_id)
+		handler = services.get_poll_handler(poll_site=poll_site)
 		poll_url = handler.get_link(poll)
 		poll_results_url = handler.get_results_link(poll)
 		return safe_format(formats["poll"], poll_url=poll_url, poll_results_url=poll_results_url)

--- a/src/module_update_shows.py
+++ b/src/module_update_shows.py
@@ -2,6 +2,7 @@ from logging import debug, info, warning, error
 from datetime import datetime, timedelta
 
 import services
+from data.database import DatabaseDatabase
 
 def main(config, db, **kwargs):
 	# Find data not provided by the edit module
@@ -122,13 +123,14 @@ def _check_new_episode_scores(config, db, update_db):
 			else:
 				info("  Already has scores, ignoring")
 
-def _record_poll_scores(config, db, update_db):
+def _record_poll_scores(config, db: DatabaseDatabase, update_db):
 	polls = db.get_polls(missing_score=True)
-	handler = services.get_default_poll_handler()
-	info(f"Record scores for service {handler.key}")
 
 	updated = 0
 	for poll in polls:
+		poll_site = db.get_poll_site(id=poll.service_id)
+		handler = services.get_poll_handler(poll_site=poll_site)
+		info(f"Record score for service {handler.key}")
 		if timedelta(days=8) < datetime.now() - poll.date < timedelta(days=93) :
 			score = handler.get_score(poll)
 			info(f"Updating poll score for show {poll.show_id} / episode {poll.episode} ({score})")

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -137,7 +137,7 @@ class Requestable:
 ###################
 
 from datetime import datetime
-from data.models import Episode, Stream, UnprocessedStream
+from data.models import Episode, PollSite, Stream, UnprocessedStream
 
 class AbstractServiceHandler(ABC, Requestable):
 	def __init__(self, key, name, is_generic):
@@ -460,4 +460,22 @@ def get_default_poll_handler() -> AbstractPollHandler:
 	:return: the handler
 	"""
 	_ensure_poll_handlers()
-	return _poll_sites["youpoll"]
+	return _poll_sites["polltab"]
+
+
+def get_poll_handler(
+		poll_site: Optional[PollSite] = None,
+		key: Optional[str] = None,
+	) -> Optional[AbstractPollHandler]:
+	"""
+	Returns an instance of a poll handler representing the given poll site.
+	:param poll_site: A poll site
+	:param key: A poll site key
+	:return: A poll handler instance
+	"""
+	_ensure_poll_handlers()
+	if poll_site is not None and poll_site.key in _poll_sites:
+		return _poll_sites[poll_site.key]
+	if key is not None and key in _poll_sites:
+		return _poll_sites[key]
+	return None

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -1,7 +1,7 @@
 from logging import debug, warning, error
 from abc import abstractmethod, ABC
 from types import ModuleType
-from typing import List, Dict, Optional, Iterable
+from typing import Any, List, Dict, Optional, Iterable
 
 # Common
 
@@ -403,7 +403,7 @@ class AbstractPollHandler(ABC, Requestable):
 		self.config = config
 
 	@abstractmethod
-	def create_poll(self, title, submit: bool) -> Optional[str]:
+	def create_poll(self, title: str, submit: bool, **kwargs: Any) -> Optional[str]:
 		"""
 		Create a new Poll.
 		:param title: title of this poll
@@ -467,7 +467,7 @@ def get_default_poll_handler() -> AbstractPollHandler:
 	:return: the handler
 	"""
 	_ensure_poll_handlers()
-	return _poll_sites["polltab"]
+	return _poll_sites["strawpoll"]
 
 
 def get_poll_handler(

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -438,6 +438,13 @@ class AbstractPollHandler(ABC, Requestable):
 		"""
 		return None
 
+	@staticmethod
+	def convert_score_str(score: Optional[float]) -> str:
+		if score is None:
+			return '----'
+		return str(score)
+
+
 _poll_sites = dict()
 
 def _ensure_poll_handlers():

--- a/src/services/poll/polltab.py
+++ b/src/services/poll/polltab.py
@@ -1,0 +1,104 @@
+import re
+from logging import debug, warning, error
+from typing import Any, Optional
+
+import requests
+from bs4 import BeautifulSoup
+
+from data.models import Poll
+from .. import AbstractPollHandler
+
+
+class PollHandler(AbstractPollHandler):
+	OPTIONS = ["Excellent", "Great", "Good", "Mediocre", "Bad"]
+
+	_poll_post_url = "https://www.polltab.com/api/poll/create"
+	_poll_post_headers = {"Content-Type": "application/json"}
+	_poll_post_data = '{{"question":"{}","questionMedia":"","choices":[{{"text":"{}"}},{{"text":"{}"}},{{"text":"{}"}},{{"text":"{}"}},{{"text":"{}"}}],"allowMultiChoice":false,"startDate":null,"endDate":null,"enableCaptcha":false,"enableComments":false,"hideResults":false,"restriction":"re"}}'
+
+	_poll_id_re = re.compile(r"polltab.com/(\d+)", re.I)
+	_poll_link = "https://polltab.com/{id}/"
+	_poll_results_link = "https://polltab.com/{id}/results/"
+
+	def __init__(self) -> None:
+		super().__init__("polltab")
+
+	def create_poll(self, title: str, submit: bool, **kwargs: Any) -> Optional[str]:
+		if not submit:
+			return None
+		headers = self._poll_post_headers
+		data = self._poll_post_data.format(title, *self.OPTIONS)
+		try:
+			resp = requests.post(self._poll_post_url, data=data, headers=headers)
+		except Exception as e:
+			error("Could not create poll (exception in POST): %s", e)
+			return None
+
+		if not resp.ok:
+			error("Could not create poll (resp !OK)")
+			return None
+
+		try:
+			poll_id = resp.json()["data"]["pollId"]
+		except (KeyError, AttributeError):
+			error("Could not retrieve poll (malformed response)")
+			return None
+		return poll_id
+
+	def get_link(self, poll: Poll) -> str:
+		return self._poll_link.format(id=poll.id)
+
+	def get_results_link(self, poll: Poll) -> str:
+		return self._poll_results_link.format(id=poll.id)
+
+	def get_score(self, poll: Poll) -> Optional[float]:
+		debug(f"Getting score for show {poll.show_id} / episode {poll.episode}")
+		try:
+			response = self.request(self.get_results_link(poll), html=True)
+			assert isinstance(response, BeautifulSoup)
+		except Exception as e:
+			error(
+				"Couldn't get scores for poll %s (query error: %s)",
+				self.get_results_link(poll),
+				e,
+			)
+			return None
+
+		try:
+			answers = [
+				a.text for a in response.find_all("div", "pollresult-chart-item-result")
+			]
+			# vote% is not returned with the request, probably calculated on the fly with a script
+			# pre-remove potential separators (,.) just in case
+			if diff := (set(answers) - set(self.OPTIONS)):
+				error("Aborted - found unexpected labels: %s", ",".join(diff))
+				return None
+			votes = [
+				int(v.text.split()[0].replace(",", "").replace(".", ""))
+				for v in response.find_all("span", "pollresult-chart-item-result-vote")
+			]
+			num_votes = sum(votes)
+			if num_votes == 0:
+				warning("No vote recorded, no score returned")
+				return None
+			votes_dict = dict(zip(answers, votes))
+			score = round(
+				sum(votes_dict[a] * i for i, a in enumerate(self.OPTIONS[::-1], 1))
+				/ num_votes,
+				2,
+			)
+			return score
+		except Exception as e:
+			error(
+				"Couldn't get scores for poll %s (parsing error: %s)",
+				self.get_results_link(poll),
+				e,
+			)
+			return None
+
+	@staticmethod
+	def convert_score_str(score: Optional[float]) -> str:
+		if score is None:
+			return "----"
+		else:
+			return str(score)

--- a/src/services/poll/polltab.py
+++ b/src/services/poll/polltab.py
@@ -95,10 +95,3 @@ class PollHandler(AbstractPollHandler):
 				e,
 			)
 			return None
-
-	@staticmethod
-	def convert_score_str(score: Optional[float]) -> str:
-		if score is None:
-			return "----"
-		else:
-			return str(score)

--- a/src/services/poll/strawpoll.py
+++ b/src/services/poll/strawpoll.py
@@ -1,0 +1,144 @@
+import logging
+import re
+from typing import Any, Optional
+
+import requests
+from bs4 import BeautifulSoup
+
+from data.models import Poll
+
+from .. import AbstractPollHandler
+
+
+class PollHandler(AbstractPollHandler):
+	OPTIONS = ["Excellent", "Great", "Good", "Mediocre", "Bad"]
+
+	_poll_post_url = "https://strawpoll.ai/poll-maker/"
+	_poll_post_data = (
+		'{{"address":"","token":"{token}","type":"0",'
+		'"questions":[{{"plurality":{{"isVoterOpts":false,"maxOpts":"10"}},'
+		'"approval":{{"type":"0","value":"1","lower":"1","upper":"1"}},'
+		'"range":{{"min":"1","max":"10"}},"integer":{{"min":"1","max":"10"}},'
+		'"rational":{{"min":"1.0","max":"10.0"}},"type":"0",'
+		'"title":"{question}","opts":['
+		+ ",".join(f'"{option}"' for option in OPTIONS)
+		+ "]}}],"
+		'"settings":{{"reddit":{{"link":"0","comment":"200","days":"0"}},'
+		'"limits":"3","isCaptcha":false,"isDeadline":false,'
+		'"isHideResults":false,"deadline":null}}}}'
+	)
+
+	_form_token_re = re.compile(
+		r"<input type=\"hidden\" id=\"pm-token\" value=\"(\w+)\">"
+	)
+
+	_poll_id_re = re.compile(r"strawpoll.ai/poll/vote/(\w+)", re.I)
+	_poll_link = "https://strawpoll.ai/poll/vote/{id}"
+	_poll_results_link = "https://strawpoll.ai/poll/results/{id}"
+
+	def __init__(self) -> None:
+		super().__init__(key="strawpoll")
+
+	def create_poll(self, title: str, submit: bool, **kwargs: Any) -> Optional[str]:
+		if not submit:
+			return None
+
+		# Obtain a poll creation form to fill
+		try:
+			form = requests.get(self._poll_post_url, timeout=10)
+		except Exception as e:
+			logging.error("Could not obtain a form to fill: %s", e)
+			return None
+
+		# Get the token associated to the form
+		try:
+			match = self._form_token_re.search(form.text)
+			assert match
+			token: str = match.group(1)
+		except Exception as e:
+			logging.error("Could not retrieve the form token: %s", e)
+			return None
+
+		# Get the session cookie associated to the form
+		try:
+			cookies = {
+				"PHPSESSID": form.headers["set-cookie"].split(";")[0].split("=")[1]
+			}
+		except Exception as e:
+			logging.error("Could not retrieve the session cookie: %s", e)
+			return None
+
+		# Submit poll creation form
+		data = self._poll_post_data.format(token=token, question=title)
+		try:
+			resp = requests.post(
+				self._poll_post_url,
+				data={"data": data},
+				cookies=cookies,
+				timeout=10,
+			)
+		except Exception as e:
+			logging.error("Could not create poll (exception in POST): %s", e)
+			return None
+
+		if not resp.ok:
+			logging.error("Could not create poll (resp !OK)")
+			return None
+
+		if match := self._poll_id_re.search(resp.url):
+			return match.group(1)
+
+		logging.error("Could not create poll (ID not found)")
+		# A failed submission normally returns the poll creation page
+		# This happens for example when the payload doesn't have a specific format
+		return None
+
+	def get_link(self, poll: Poll) -> str:
+		return self._poll_link.format(id=poll.id)
+
+	def get_results_link(self, poll: Poll) -> str:
+		return self._poll_results_link.format(id=poll.id)
+
+	def get_score(self, poll: Poll) -> Optional[float]:
+		logging.debug(
+			"Getting score for show %s / episode %d", poll.show_id, poll.episode
+		)
+		try:
+			response = self.request(url=self.get_results_link(poll), html=True)
+			assert isinstance(response, BeautifulSoup)
+		except Exception:
+			logging.error(
+				"Couldn't get scores for poll %s (GET request failed)",
+				self.get_results_link(poll),
+			)
+			return None
+
+		try:
+			labels: list[str] = [
+				x.text.strip() for x in response.find_all("div", "rslt-plurality-txt")
+			]
+			if diff := (set(labels) - set(self.OPTIONS)):
+				logging.error("Aborted - found unexpected labels: %s", ",".join(diff))
+				return None
+			votes = [
+				int(x.text.strip().replace(",", "").replace(".", ""))
+				for x in response.find_all("div", "rslt-plurality-votes")
+			]
+			num_votes = int(response.find("span", "rslt-total-votes").text.strip())
+			if num_votes == 0:
+				logging.warning("No vote recorded, no score returned")
+				return None
+			votes_dict = dict(zip(labels, votes))
+			score = round(
+				sum(votes_dict[a] * i for i, a in enumerate(self.OPTIONS[::-1], 1))
+				/ num_votes,
+				2,
+			)
+			return score
+		except Exception as e:
+			logging.error(
+				"Couldn't get scores for poll %s - parsing error: %s",
+				self.get_results_link(poll),
+				e,
+			)
+			return None

--- a/src/services/poll/youpoll.py
+++ b/src/services/poll/youpoll.py
@@ -44,6 +44,7 @@ class PollHandler(AbstractPollHandler):
 	def create_poll(self, title: str, submit: bool, **kwargs: Any)-> Optional[str]:
 		if not submit:
 			return None
+		raise RuntimeError("Cannot create polls on youpoll.me")
 		#headers = _poll_post_headers
 		#headers['User-Agent'] = config.useragent
 		data = self._poll_post_data

--- a/src/services/poll/youpoll.py
+++ b/src/services/poll/youpoll.py
@@ -103,10 +103,3 @@ class PollHandler(AbstractPollHandler):
 		except Exception as e:
 			error("Couldn't get scores for poll %s - parsing error: %s", self.get_results_link(poll), e)
 			return None
-
-
-	@staticmethod
-	def convert_score_str(score: Optional[float]) -> str:
-		if score is None:
-			return '----'
-		return str(score)

--- a/src/services/poll/youpoll.py
+++ b/src/services/poll/youpoll.py
@@ -53,12 +53,15 @@ class PollHandler(AbstractPollHandler):
 			error("Could not create poll (exception in POST)")
 			return None
 
-		if resp.ok:
-			match = self._poll_id_re.search(resp.url)
-			return match.group(1)
-		else:
+		if not resp.ok:
 			error("Could not create poll (resp !OK)")
 			return None
+		
+		match = self._poll_id_re.search(resp.url)
+		if not match:
+			error("Could not create poll (URL not found)")
+			return None
+		return match.group(1)
 
 	def get_link(self, poll):
 		return self._poll_link.format(id = poll.id)


### PR DESCRIPTION
Add strawpoll.ai as the new default poll service (site redesign of the previous default youpoll.me)

* Deprecate youpoll for poll creation
* youpoll URLs can still be used to view existing polls, as they redirect to strawpoll (poll result retrieval is updated accordingly)
* Add a function to select the appropriate poll handler, now that there is more than one
* Add polltab as an alternative poll service because why not


Test example: [a show using different services for each episode](https://imgur.com/a/OjoXdqF) and [the resulting thread](https://streamable.com/3yzdmp)