### PR TITLE
Update HIDIVE show key regex

### DIFF
--- a/src/services/stream/hidive.py
+++ b/src/services/stream/hidive.py
@@ -7,7 +7,7 @@ from data.models import Episode, UnprocessedStream
 
 class ServiceHandler(AbstractServiceHandler):
     _show_url = "https://www.hidive.com/tv/{id}"
-    _show_re = re.compile("hidive.com/tv/([\w-]+)", re.I)
+    _show_re = re.compile(r"hidive\.com/tv/([\w-]+(?:/season-\d+)?)", re.I)
 
     def __init__(self):
         super().__init__("hidive", "HIDIVE", False)


### PR DESCRIPTION
Sequel seasons have an additional  `/season-x` in the URL, which the current regex does not catch - see for example today's BokuYaba episode (thread timing and my local logs match [Erai-raws] release)

[Example test strings](https://regex101.com/r/c1OoJq/1)

Episode numbers seem to continue from previous seasons, at least for the shows I checked, so an appropriate episode number offset need to be added (e.g. `|12` for BokuYaba)

(NOTE: when running the `edit` command after this update, the affected series should spawn new entries in the `Streams` table, so existing active entries for the same show should be updated accordingly, both in the `Streams` and in the `Episodes` table)