### PR TITLE
Make the English title matchable

### DIFF
--- a/src/services/stream/nyaa.py
+++ b/src/services/stream/nyaa.py
@@ -75,6 +75,9 @@ class ServiceHandler(AbstractServiceHandler):
 			show = stream.show
 			names = [show.name] + show.aliases + [stream.show_key]
 
+			if show.name_en:
+				names.append(show.name_en)
+
 			for name in names:
 				#debug(f"  Trying: {name}")
 				# Match if each word in the show name is in the torrent name


### PR DESCRIPTION
When available, add the English title of an anime as a valid match for a torrent file name