### PR TITLE
Replace deprecated method `datetime.utcnow`

### DIFF
--- a/src/data/database.py
+++ b/src/data/database.py
@@ -3,7 +3,7 @@ import sqlite3, re
 from functools import wraps, lru_cache
 from unidecode import unidecode
 from typing import Set, List, Optional
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 from .models import Show, ShowType, Stream, LiteStream, Service, LinkSite, Link, Episode, EpisodeScore, UnprocessedStream, UnprocessedShow, PollSite, Poll
 
@@ -668,7 +668,7 @@ class DatabaseDatabase:
 
 	@db_error
 	def add_poll(self, show: Show, episode: Episode, site: PollSite, poll_id, commit=True):
-		ts = int(datetime.now(timezone.utc).timestamp())
+		ts = int(datetime.now(UTC).timestamp())
 		self.q.execute("INSERT INTO Polls (show, episode, poll_service, poll_id, timestamp) VALUES (?, ?, ?, ?, ?)", (show.id, episode.number, site.id, poll_id, ts))
 		if commit:
 			self.commit()

--- a/src/data/models.py
+++ b/src/data/models.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 import enum
 import copy
 
@@ -69,9 +69,8 @@ class Episode:
 		return "Episode: {} | Episode {}, {} ({})".format(self.date, self.number, self.name, self.link)
 	
 	@property
-	def is_live(self, local=False):
-		now = datetime.now() if local else datetime.utcnow()
-		return now >= self.date
+	def is_live(self):
+		return datetime.now(UTC).replace(tzinfo=None) >= self.date
 
 class EpisodeScore:
 	def __init__(self, show_id, episode, site_id, score):

--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -136,7 +136,7 @@ class Requestable:
 # Service handler #
 ###################
 
-from datetime import datetime
+from datetime import UTC, datetime
 from data.models import Episode, Stream, UnprocessedStream
 
 class AbstractServiceHandler(ABC, Requestable):
@@ -168,7 +168,7 @@ class AbstractServiceHandler(ABC, Requestable):
 		:return: An iterable of live episodes
 		"""
 		episodes = self.get_all_episodes(stream, **kwargs)
-		today = datetime.utcnow().date()							#NOTE: Uses local time instead of UTC, but probably doesn't matter too much on a day scale
+		today = datetime.now(UTC).replace(tzinfo=None).date()							#NOTE: Uses local time instead of UTC, but probably doesn't matter too much on a day scale
 		return filter(lambda e: e.date.date() <= today, episodes)	# Update 9/14/16: It actually matters.
 	
 	@abstractmethod

--- a/src/services/stream/adultswim.py
+++ b/src/services/stream/adultswim.py
@@ -1,6 +1,6 @@
 from logging import debug, info, warning, error, exception
 import re
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 import dateutil.parser
 
 from .. import AbstractServiceHandler
@@ -89,13 +89,14 @@ def _is_valid_episode(episode_data, show_key):
     date_string = episode_data.find("meta", itemprop="datePublished")["content"]
     date = datetime.fromordinal(dateutil.parser.parse(date_string).toordinal())
 
-    if date > datetime.utcnow():
-	    return False
+    date_diff = datetime.now(UTC).replace(tzinfo=None) - date
 
-    date_diff = datetime.utcnow() - date
+    if date_diff < timedelta(0):
+        return False
+
     if date_diff >= timedelta(days=2):
-	    debug("  Episode too old")
-	    return False
+        debug("  Episode too old")
+        return False
 
     return True
 

--- a/src/services/stream/crunchyroll.py
+++ b/src/services/stream/crunchyroll.py
@@ -1,6 +1,6 @@
 from logging import debug, info, warning, error, exception
 import re
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 from .. import AbstractServiceHandler
 from data.models import Episode, UnprocessedStream
@@ -172,7 +172,7 @@ def _is_valid_episode(feed_episode, show_id):
 		return False
 	# Don't check really old episodes
 	episode_date = datetime(*feed_episode.published_parsed[:6])
-	date_diff = datetime.utcnow() - episode_date
+	date_diff = datetime.now(UTC).replace(tzinfo=None) - episode_date
 	if date_diff >= timedelta(days=2):
 		debug("  Episode too old")
 		return False

--- a/src/services/stream/hidive.py
+++ b/src/services/stream/hidive.py
@@ -1,6 +1,6 @@
 from logging import debug, info, warning, error, exception
 import re
-from datetime import datetime, timedelta
+from datetime import UTC, datetime
 
 from .. import AbstractServiceHandler
 from data.models import Episode, UnprocessedStream
@@ -133,6 +133,6 @@ def _digest_episode(feed_episode):
         name = None
 
     link = episode_link
-    date = datetime.utcnow() # Not included in stream !
+    date = datetime.now(UTC).replace(tzinfo=None) # Not included in stream !
 
     return Episode(num, name, link, date)

--- a/src/services/stream/nyaa.py
+++ b/src/services/stream/nyaa.py
@@ -2,7 +2,7 @@
 # Show search (RSS): https://www.nyaa.eu/?page=rss&cats=1_37&filter=2&term=
 
 from logging import debug, info, warning, error, exception
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 import re
 from urllib.parse import quote_plus as url_quote
 
@@ -171,7 +171,7 @@ def _is_valid_episode(feed_episode):
 		debug("  Excluded")
 		return False
 	episode_date = datetime(*feed_episode.published_parsed[:6])
-	date_diff = datetime.utcnow() - episode_date
+	date_diff = datetime.now(UTC).replace(tzinfo=None) - episode_date
 	if date_diff >= timedelta(days=2):
 		debug("  Episode too old")
 		return False
@@ -187,7 +187,7 @@ def _digest_episode(feed_episode):
 	episode_num = _extract_episode_num(title)
 	if episode_num is not None:
 		debug("  Match found, num={}".format(episode_num))
-		date = feed_episode["published_parsed"] or datetime.utcnow()
+		date = feed_episode["published_parsed"] or datetime.now(UTC).replace(tzinfo=None)
 		link = feed_episode["id"]
 		return Episode(episode_num, None, link, date)
 	debug("  No match found")

--- a/src/services/stream/youtube.py
+++ b/src/services/stream/youtube.py
@@ -1,6 +1,6 @@
 from logging import debug, info, warning, error, exception
 import re
-from datetime import datetime, timedelta
+from datetime import UTC, datetime
 
 from .. import AbstractServiceHandler
 from data.models import Episode, UnprocessedStream
@@ -161,7 +161,7 @@ def _digest_episode(feed_episode):
 
 	date_string = snippet["publishedAt"].replace('Z', '')
 	#date_string = snippet["publishedAt"].replace('Z', '+00:00') # Use this for offset-aware dates
-	date = datetime.fromisoformat(date_string) or datetime.utcnow()
+	date = datetime.fromisoformat(date_string) or datetime.now(UTC).replace(tzinfo=None)
 
 	link = _video_url.format(video_id=feed_episode["id"])
 	return Episode(episode_num, None, link, date)


### PR DESCRIPTION
`datetime.utcnow` is deprecated with Python 3.12, and eventually will be removed (see [here](https://discuss.python.org/t/deprecating-utcnow-and-utcfromtimestamp/26221)).

Ideally everything should be made timezone-aware, but for now this commit simply replaces calls to `datetime.utcnow()` by calling `datetime.now(UTC)` and stripping the timezone information to make it naive, to keep the current behaviour.

(also remove the `local` flag from `Episode.is_live`, it is never used and it never could be since properties don't take arguments)