### PR TITLE
Exclude GBC MTL subs

### DIFF
--- a/src/services/stream/nyaa.py
+++ b/src/services/stream/nyaa.py
@@ -202,7 +202,7 @@ _exludors = [re.compile(x, re.I) for x in [
 	r"\b(bd|bluray|bdrip)\b",
 	r"PV.?\d+",
 	r"pre-?air",
-	r"(blackjaxx|daddy)", # blacklisted uploaders
+	r"(blackjaxx|daddy|le m[eê]me)", # blacklisted uploaders
 ]]
 _num_extractors = [re.compile(x, re.I) for x in [
 	# " - " separator between show and episode


### PR DESCRIPTION
Girl Band Cry consistently gets MTL speedsubs from one uploader, resulting in the episode thread getting removed.