### PR TITLE
Update long.yaml One Piece streams

### DIFF
--- a/season_configs/long.yaml
+++ b/season_configs/long.yaml
@@ -11,10 +11,6 @@ info:
   subreddit: '/r/OnePiece'
 streams:
   crunchyroll: 'https://www.crunchyroll.com/one-piece'
-  funimation|Funimation: 'https://www.funimation.com/shows/one-piece/'
-  animelab|AnimeLab: 'https://www.animelab.com/shows/one-piece'
-  vrv|VRV: 'https://vrv.co/series/GRMG8ZQZR/One-Piece'
-  nyaa: 'One Piece'
 ---
 title: 'Yu-Gi-Oh! VRAINS'
 alias: ['Yu☆Gi☆Oh! VRAINS', 'Yuu Gi Ou: Vrains']


### PR DESCRIPTION
One Piece still lists VRV and Funi as streaming services when those have both died. Proposing that they are removed from further threads.