### PR TITLE
Replace r/mushokutensei with r/sixfacedworld in discussion post

### DIFF
--- a/season_configs/spring_2024.yaml
+++ b/season_configs/spring_2024.yaml
@@ -686,7 +686,7 @@ info:
   kitsu: 'https://kitsu.io/anime/47694'
   animeplanet: 'http://www.anime-planet.com/anime/mushoku-tensei-jobless-reincarnation-2nd-season-part-ii'
   official: 'https://mushokutensei.jp/'
-  subreddit: '/r/mushokutensei'
+  subreddit: '/r/sixfacedworld'
 streams:
   crunchyroll: 'https://www.crunchyroll.com/mushoku-tensei-jobless-reincarnation'
   museasia: ''


### PR DESCRIPTION
Good evening,

I'm a mod from [r/sixfacedworld](https://new.reddit.com/r/sixfacedworld), a Mushoku Tensei subreddit. I noticed that, in your discussion posts you link to [r/mushokutensei](https://new.reddit.com/r/mushokutensei).

That wouldn't be a problem, but [r/mushokutensei](https://new.reddit.com/r/mushokutensei) is barely moderated. 

It hasn't received an update in years. They allow excessive NSFW (loli) content, Loli in general and overall don't remove community harming hate comments. 

Spoilers are okay too. The moderation team is ignoring any input or help offered from other members.

Some supporting proof:

https://www.reddit.com/r/mushokutensei/comments/171medf/whats_the_difference_between_rmushokutensei_and/

https://www.reddit.com/r/mushokutensei/comments/s57dgo/we_should_all_migrate_to_rsixfacedworld/

Thats why [r/sixfacedworld](https://new.reddit.com/r/sixfacedworld) was put into existence. We care about the subreddit and the community. Recently we banned any kind of Loli content. We care about keeping our community spoiler-free. We are also partnered with the Mushoku Tensei Discord server which sits at currently 24k members.

I'd suggest you to remove [r/mushokutensei](https://new.reddit.com/r/mushokutensei) and replace it with [r/sixfacedworld](https://new.reddit.com/r/sixfacedworld).

Thank you for your consideration.