### PR TITLE
Display inactive streams in post body

### DIFF
--- a/src/data/database.py
+++ b/src/data/database.py
@@ -272,8 +272,7 @@ class DatabaseDatabase:
 		elif show is not None:
 			debug("Getting all streams for show {}".format(show.id))
 			self.q.execute("SELECT id, service, show, show_id, show_key, name, remote_offset, display_offset, active FROM Streams \
-							WHERE show = ? AND active = 1 AND \
-							(SELECT enabled FROM Shows WHERE id = show) = 1", (show.id,))
+							WHERE show = ? AND (SELECT enabled FROM Shows WHERE id = show) = 1", (show.id,))
 		elif unmatched:
 			debug("Getting unmatched streams")
 			self.q.execute("SELECT id, service, show, show_id, show_key, name, remote_offset, display_offset, active FROM Streams \

--- a/src/data/database.py
+++ b/src/data/database.py
@@ -261,39 +261,27 @@ class DatabaseDatabase:
 		return stream
 
 	@db_error_default(list())
-	def get_streams(self, service=None, show=None, active=True, unmatched=False, missing_name=False) -> List[Stream]:
+	def get_streams(self, service=None, show=None, unmatched=False, missing_name=False) -> List[Stream]:
 		# Not the best combination of options, but it's only the usage needed
-		if service is not None and active == True:
+		if service is not None:
 			debug("Getting all active streams for service {}".format(service.key))
 			service = self.get_service(key=service.key)
 			self.q.execute("SELECT id, service, show, show_id, show_key, name, remote_offset, display_offset, active FROM Streams \
 							WHERE service = ? AND active = 1 AND \
 							(SELECT enabled FROM Shows WHERE id = show) = 1", (service.id,))
-		elif service is not None and active == False:
-			debug("Getting all inactive streams for service {}".format(service.key))
-			service = self.get_service(key=service.key)
-			self.q.execute("SELECT id, service, show, show_id, show_key, name, remote_offset, display_offset, active FROM Streams \
-							WHERE service = ? AND active = 0", (service.id,))
-		elif show is not None and active == True:
+		elif show is not None:
 			debug("Getting all streams for show {}".format(show.id))
 			self.q.execute("SELECT id, service, show, show_id, show_key, name, remote_offset, display_offset, active FROM Streams \
 							WHERE show = ? AND active = 1 AND \
 							(SELECT enabled FROM Shows WHERE id = show) = 1", (show.id,))
-		elif show is not None and active == False:
-			debug("Getting all streams for show {}".format(show.id))
-			self.q.execute("SELECT id, service, show, show_id, show_key, name, remote_offset, display_offset, active FROM Streams \
-							WHERE show = ? AND active = 0", (show.id,))
 		elif unmatched:
 			debug("Getting unmatched streams")
 			self.q.execute("SELECT id, service, show, show_id, show_key, name, remote_offset, display_offset, active FROM Streams \
 							WHERE show IS NULL")
-		elif missing_name and active == True:
+		elif missing_name:
 			self.q.execute("SELECT id, service, show, show_id, show_key, name, remote_offset, display_offset, active FROM Streams \
 							WHERE (name IS NULL OR name = '') AND active = 1 AND \
 							(SELECT enabled FROM Shows WHERE id = show) = 1")
-		elif missing_name and active == False:
-			self.q.execute("SELECT id, service, show, show_id, show_key, name, remote_offset, display_offset, active FROM Streams \
-							WHERE (name IS NULL OR name = '') AND active = 0")
 		else:
 			error("A service or show must be provided to get streams")
 			return list()

--- a/src/module_find_episodes.py
+++ b/src/module_find_episodes.py
@@ -211,12 +211,11 @@ def _gen_text_streams(db, formats, show):
 
 	streams = db.get_streams(show=show)
 	for stream in streams:
-		if stream.active:
-			service = db.get_service(id=stream.service)
-			if service.enabled and service.use_in_post:
-				service_handler = services.get_service_handler(service)
-				text = safe_format(formats["stream"], service_name=service.name, stream_link=service_handler.get_stream_link(stream))
-				stream_texts.append(text)
+		service = db.get_service(id=stream.service)
+		if service.enabled and service.use_in_post:
+			service_handler = services.get_service_handler(service)
+			text = safe_format(formats["stream"], service_name=service.name, stream_link=service_handler.get_stream_link(stream))
+			stream_texts.append(text)
 		
 	lite_streams = db.get_lite_streams(show=show)
 	for lite_stream in lite_streams:


### PR DESCRIPTION
This will allow us to set youtube streams (or any other stream url that breaks things) to inactive when needed, so Holo does not improperly fire off them, but still have them be displayed in the post body.

I also simplified get_streams by removing an argument that's never changed from its default value.

Testing on animestaging makes me at least somewhat confident that this will not break something else. 