### PR TITLE
Fix hidive

### DIFF
--- a/src/services/__init__.py
+++ b/src/services/__init__.py
@@ -68,9 +68,8 @@ def rate_limit(wait_length):
 class Requestable:
 	rate_limit_wait = 1
 	
-	@lru_cache(maxsize=100)
 	@rate_limit(rate_limit_wait)
-	def request(self, url, json=False, xml=False, html=False, rss=False, proxy=None, useragent=None, auth=None, timeout=10):
+	def request(self, url, json=False, xml=False, html=False, rss=False, proxy=None, useragent=None, auth=None, headers=None, timeout=10):
 		"""
 		Sends a request to the service.
 		:param url: The request URL
@@ -80,6 +79,7 @@ class Requestable:
 		:param proxy: Optional proxy, a tuple of address and port
 		:param useragent: Ideally should always be set
 		:param auth: Tuple of username and password to use for HTTP basic auth
+		:param headers: Any additional headers
 		:param timeout: Amount of time to wait for a response in seconds
 		:return: The response if successful, otherwise None
 		"""
@@ -91,7 +91,9 @@ class Requestable:
 				proxy = {"http": "http://{}:{}".format(*proxy)}
 				debug("Using proxy: {}", proxy)
 		
-		headers = {"User-Agent": useragent}
+		if headers == None:
+			headers = {}
+		headers["User-Agent"] = useragent
 		debug("Sending request")
 		debug("  URL={}".format(url))
 		debug("  Headers={}".format(headers))

--- a/src/services/stream/hidive.py
+++ b/src/services/stream/hidive.py
@@ -11,7 +11,19 @@ class ServiceHandler(AbstractServiceHandler):
     # we must support both versions.
     _show_url = "https://www.hidive.com/{id}"
     _show_res = [re.compile("hidive.com/(tv/[\w-]+)", re.I),
-                re.compile("hidive.com/(season/\d+)", re.I)]
+                 re.compile("hidive.com/(season/\d+)", re.I)]
+
+    # An undocumented HiDive API that appears to be used by its mobile app.
+    # Inspiration taken from https://github.com/anidl/multi-downloader-nx/blob/master/hidive.ts
+    # rpp is the number of episodes fetched. It only goes to 20.
+    _api_query = "https://dce-frontoffice.imggaming.com/api/v4/{key}?rpp=20"
+    _api_headers = {'X-Api-Key': '857a1e5d-e35e-4fdf-805b-a87b6f8364bf',
+                    'X-App-Var': '6.0.1.bbf09a2',
+                    'realm': 'dce.hidive',
+                    'Referer': 'https://www.hidive.com/',
+                    'Origin': 'https://www.hidive.com'
+                   }
+    _api_auth_token = None
 
     def __init__(self):
         super().__init__("hidive", "HIDIVE", False)
@@ -42,26 +54,71 @@ class ServiceHandler(AbstractServiceHandler):
     def _get_feed_episodes(self, show_key, **kwargs):
         info(f"Getting episodes for HiDive/{show_key}")
 
-        url = self._get_feed_url(show_key)
+        headers = self._api_headers
+        headers['Authorization'] = "Bearer " + self._get_api_auth_token()
+        last_seen = None
+        episodes = []
 
-        # Send request
-        response = self.request(url, html=True, **kwargs)
-        if response is None:
-            error(f"Cannot get show page for HiDive/{show_key}")
-            return list()
+        # This will cover the first 400 episodes. Currently, the odds of a Hidive
+        # show having more than 400 episodes seems lower than the odds of Hidive's
+        # api bugging and always saying there are more episodes, which would otherwise
+        # stall holo forever.
+        for _ in range(20):
+            url = self._get_feed_url(show_key, last_seen)
+            response = self.request(url, json=True, headers=headers, **kwargs)
+            if response is None:
+                error(f"Cannot get show page for HiDive/{show_key}")
+                return list()
 
-        # Parse html page
-        sections = response.find_all("div", {"data-section": "episodes"})
-        #return [section.a['data-playurl'] for section in sections if section.a]
-        return sections
+            for ep in response['episodes']:
+                if "onlinePlayback" in ep:
+                    if ep["onlinePlayback"] == "AVAILABLE":
+                        episodes.append(ep)
+                else:
+                    warning("  HiDive API returned JSON not matching expectations: onlinePlayback")
+
+            if ( "paging" in response and "moreDataAvailable" in response["paging"]
+                  and "lastSeen" in response["paging"]):
+                if response["paging"]["moreDataAvailable"]:
+                    last_seen = response["paging"]["lastSeen"]
+                    debug("Fetching additional page from HiDive's API")
+                else:
+                    break
+            else:
+                warning("  HiDive API returned JSON not matching expectations: paging")
+                break
+
+        return episodes
 
 
     @classmethod
-    def _get_feed_url(cls, show_key):
-        if show_key is not None:
-            return cls._show_url.format(id=show_key)
+    def _get_feed_url(cls, show_key, last_seen=None):
+        # This api only works with /season/ style hidive identifiers.
+        if show_key is not None and show_key.startswith("season/"):
+            url =  cls._api_query.format(key=show_key)
+            if last_seen is not None:
+                url += "&lastSeen=" + str(last_seen)
+            return url
         else:
             return None
+
+    @classmethod
+    def _get_api_auth_token(cls):
+        # The auth token easily lasts a full holo run, so we assume any one we have is valid.
+        # If just getting through all HiDive shows takes longer than the token lasts,
+        # we have far greater issues.
+        if cls._api_auth_token:
+            debug("  HiDive API key from cache")
+            return cls._api_auth_token
+
+        init = cls.request(cls, "https://dce-frontoffice.imggaming.com/api/v1/init",
+                            headers=cls._api_headers, json=True)
+        tok = init['authentication']['authorisationToken']
+        cls._api_auth_token = tok
+        debug("  HiDive API key from endpoint")
+        return tok
+
+
 
     # Remove info getting
 
@@ -69,18 +126,18 @@ class ServiceHandler(AbstractServiceHandler):
         info(f"Getting stream info for HiDive/{stream.show_key}")
 
         url = self._get_feed_url(stream.show_key)
-        response = self.request(url, html=True, **kwargs)
+        headers = self._api_headers
+        headers['Authorization'] = "Bearer " + self._get_api_auth_token()
+        response = self.request(url, json=true, headers=headers, **kwargs)
         if response is None:
             error("Cannot get feed")
             return None
 
-        title_section = response.find("div", {"class": "episodes"})
-        if title_section is None:
-           error("Could not extract title")
-           return None
+        if "series" in response and "title" in response["series"]:
+            return response["series"]["title"]
 
-        stream.name = title_section.h1.text
-        return stream
+        error("Could not extract title")
+        return None
 
     def get_seasonal_streams(self, **kwargs):
         # What is this for again ?
@@ -96,48 +153,28 @@ class ServiceHandler(AbstractServiceHandler):
                 return match.group(1)
         return None
 
-_episode_re = re.compile("(?:https://www.hidive.com)?/stream/[\w-]+/s\d{2}e(\d{3})", re.I)
-_episode_re_alter = re.compile("(?:https://www.hidive.com)?/stream/[\w-]+/\d{4}\d{2}\d{2}(\d{2})", re.I)
-_episode_name_correct = re.compile("(?:E\d+|Shorts) ?\| ?(.*)")
-_episode_name_invalid = re.compile(".*coming soon.*", re.I)
-
 def _is_valid_episode(episode_data, show_key):
-    # Possibly other cases to watch ?
-    if episode_data.a is None:
-        return False
-    #return re.match(_episode_re.format(id=show_key), episode_data) is not None
-
-    return True
+    if ( "episodeInformation" in episode_data
+         and "episodeNumber" in episode_data["episodeInformation"]
+         and "title" in episode_data and "id" in episode_data ):
+           return True
+    warning("  HiDive API returned JSON not matching expectations: episode data")
+    return False
 
 def _digest_episode(feed_episode):
     debug("Digesting episode")
 
-    episode_link = feed_episode.a['href']
-
-    # Get data
-    num_match = _episode_re.match(episode_link)
-    num_match_alter = _episode_re_alter.match(episode_link)
-    if num_match:
-        num = int(num_match.group(1))
-    elif num_match_alter:
-        warning("Using alternate episode key format")
-        num = int(num_match_alter.group(1))
-    else:
-        warning(f"Unknown episode number format in {episode_link}")
-        return None
+    num = feed_episode["episodeInformation"]["episodeNumber"]
     if num <= 0:
+        debug("Rejected episode for invalid number: {}", num)
         return None
 
-    name = feed_episode.h2.text
-    name_match = _episode_name_correct.match(name)
-    if name_match:
-        debug(f"  Corrected title from {name}")
-        name = name_match.group(1)
-    if _episode_name_invalid.match(name):
-        warning(f"  Episode title not found")
-        name = None
+    # Remove the leading 'E\d+ - ' from the title.
+    name = feed_episode["title"].split(" - ", maxsplit=1)[1]
 
-    link = episode_link
-    date = datetime.utcnow() # Not included in stream !
+    link = "https://www.hidive.com/video/" + str(feed_episode["id"])
+
+    # The API does not return a timestamp.
+    date = datetime.utcnow()
 
     return Episode(num, name, link, date)


### PR DESCRIPTION
There's two parts to this PR. The first commit is a fairly simple fix for the new style of hidive URLs. It also supports the older style of hidive URLs because they're still a perfectly valid (if less precise) way to refer to a show on hidive. Converting the DB from the old style to the new style only requires
```sql
UPDATE streams AS t SET show_key=(SELECT 'tv/' || s.show_key FROM streams s WHERE s.id = t.id) WHERE t.service = 8;
```

The next two commits let us actually get hidive shows directly from hidive again. I'm honestly not sure the last time this worked. Our old code for that scraped the hidive show pages themselves, which broke completely when hidive switched to rendering everything with javascript. The new approach uses an undocumented API that I learned about from [this code here](https://github.com/anidl/multi-downloader-nx/blob/master/hidive.ts). The parts of the API we depend on seem sufficiently stable; they appear to have not changed at all for at least the last 12 months. 

I'm running this against animestaging now and everything seems to be fine. If everything continues to work for the next few days, I'll likely merge and update the main bot.